### PR TITLE
fix: missing "ASVS V5 Input validation and output encoding" URL

### DIFF
--- a/2017/en/0xa1-injection.md
+++ b/2017/en/0xa1-injection.md
@@ -45,7 +45,7 @@ This changes the meaning of both queries to return all the records from the acco
 ### OWASP
 
 * [OWASP Proactive Controls: Parameterize Queries](https://www.owasp.org/index.php/OWASP_Proactive_Controls#2:_Parameterize_Queries)
-* [OWASP ASVS: V5 Input Validation and Encoding](TBA)
+* [OWASP ASVS: V5 Input Validation and Encoding](https://www.owasp.org/index.php/ASVS_V5_Input_validation_and_output_encoding)
 * [OWASP Testing Guide: SQL Injection](https://www.owasp.org/index.php/Testing_for_SQL_Injection_(OTG-INPVAL-005)), [Command Injection](https://www.owasp.org/index.php/Testing_for_Command_Injection_(OTG-INPVAL-013)), [ORM injection](https://www.owasp.org/index.php/Testing_for_ORM_Injection_(OTG-INPVAL-007))
 * [OWASP Cheat Sheet: Injection Prevention](https://www.owasp.org/index.php/Injection_Prevention_Cheat_Sheet)
 * [OWASP Cheat Sheet: SQL Injection Prevention](https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet)


### PR DESCRIPTION
The URL pointing to "ASVS V5 Input validation and output encoding" is missing in `0xa1-injection.md` at `golden-master`.