### PR TITLE
Update link to ASVS page V1 Architecture

### DIFF
--- a/2017/en/0xa9-known-vulns.md
+++ b/2017/en/0xa9-known-vulns.md
@@ -41,7 +41,7 @@ There are automated tools to help attackers find unpatched or misconfigured syst
 
 ### OWASP
 
-* [OWASP Application Security Verification Standard: V1 Architecture, design and threat modelling](https://www.owasp.org/index.php/ASVS_V1_Architecture)
+* [OWASP Application Security Verification Standard: V1 Architecture, design and threat modelling](https://www.owasp.org/index.php/OWASP_Proactive_Controls#8:_Implement_Logging_and_Intrusion_Detection)
 * [OWASP Dependency Check (for Java and .NET libraries)](https://www.owasp.org/index.php/OWASP_Dependency_Check)
 * [OWASP Testing Guide - Map Application Architecture (OTG-INFO-010)](https://www.owasp.org/index.php/Map_Application_Architecture_(OTG-INFO-010))
 * [OWASP Virtual Patching Best Practices](https://www.owasp.org/index.php/Virtual_Patching_Best_Practices)


### PR DESCRIPTION
Update the link in the Section A9: Using Components
with Known Vulnerabilities which pointed to a site, that is recommended for deletion.

(with respect to https://github.com/OWASP/Top10/pull/431)