### PR TITLE
Fix typo in broken authentication

### DIFF
--- a/2017/OWASP-Top-10-2017-en.html
+++ b/2017/OWASP-Top-10-2017-en.html
@@ -383,7 +383,7 @@
 <li>Permits brute force or other automated attacks.</li>
 <li>Permits default, weak, or well-known passwords, such as &quot;Password1&quot; or &quot;admin/admin“.</li>
 <li>Uses weak or ineffective credential recovery and forgot-password processes, such as &quot;knowledge-based answers&quot;, which cannot be made safe.</li>
-<li>Uses plain text, encrypted, or weakly hashed passwords (see <strong>A3:2017-Sensitive Data Exposure</strong>).</li>
+<li>Uses plain text, unencrypted, or weakly hashed passwords (see <strong>A3:2017-Sensitive Data Exposure</strong>).</li>
 <li>Has missing or ineffective multi-factor authentication.</li>
 <li>Exposes Session IDs in the URL (e.g., URL rewriting).</li>
 <li>Does not rotate Session IDs after successful login.</li>

--- a/2017/OWASP-Top-10-2017-fr.html
+++ b/2017/OWASP-Top-10-2017-fr.html
@@ -363,7 +363,7 @@
 <li>Permits brute force or other automated attacks.</li>
 <li>Permits default, weak, or well-known passwords, such as &quot;Password1&quot; or &quot;admin/admin“.</li>
 <li>Uses weak or ineffective credential recovery and forgot-password processes, such as &quot;knowledge-based answers&quot;, which cannot be made safe.</li>
-<li>Uses plain text, encrypted, or weakly hashed passwords (see <strong>A3:2017-Sensitive Data Exposure</strong>).</li>
+<li>Uses plain text, unencrypted, or weakly hashed passwords (see <strong>A3:2017-Sensitive Data Exposure</strong>).</li>
 <li>Has missing or ineffective multi-factor authentication.</li>
 <li>Exposes Session IDs in the URL (e.g., URL rewriting).</li>
 <li>Does not rotate Session IDs after successful login.</li>

--- a/2017/en/0xa2-broken-authentication.md
+++ b/2017/en/0xa2-broken-authentication.md
@@ -15,7 +15,7 @@ There may be authentication weaknesses if the application:
 * Permits brute force or other automated attacks.
 * Permits default, weak, or well-known passwords, such as "Password1" or "admin/admin“.
 * Uses weak or ineffective credential recovery and forgot-password processes, such as "knowledge-based answers", which cannot be made safe.
-* Uses plain text, encrypted, or weakly hashed passwords (see **A3:2017-Sensitive Data Exposure**).
+* Uses plain text, unencrypted, or weakly hashed passwords (see **A3:2017-Sensitive Data Exposure**).
 * Has missing or ineffective multi-factor authentication.
 * Exposes Session IDs in the URL (e.g., URL rewriting).
 * Does not rotate Session IDs after successful login.

--- a/2017/he/0xa2-broken-authentication.md
+++ b/2017/he/0xa2-broken-authentication.md
@@ -15,7 +15,7 @@ There may be authentication weaknesses if the application:
 * Permits brute force or other automated attacks.
 * Permits default, weak, or well-known passwords, such as "Password1" or "admin/admin“.
 * Uses weak or ineffective credential recovery and forgot-password processes, such as "knowledge-based answers", which cannot be made safe.
-* Uses plain text, encrypted, or weakly hashed passwords (see **A3:2017-Sensitive Data Exposure**).
+* Uses plain text, unencrypted, or weakly hashed passwords (see **A3:2017-Sensitive Data Exposure**).
 * Has missing or ineffective multi-factor authentication.
 * Exposes Session IDs in the URL (e.g., URL rewriting).
 * Does not rotate Session IDs after successful login.


### PR DESCRIPTION
Noticed a pretty confusing typo when reading the 2017 spec for Broken Authentication, assuming I haven't dramatically misunderstood its intention!

Also have PRs for the same issue in [www-project-top-ten](https://github.com/OWASP/www-project-top-ten/pull/24) and [RiskAssessmentFramework](https://github.com/OWASP/RiskAssessmentFramework/pull/60).