### PR TITLE
Trivial formatting fix

### DIFF
--- a/2021/docs/A09_2021-Security_Logging_and_Monitoring_Failures.md
+++ b/2021/docs/A09_2021-Security_Logging_and_Monitoring_Failures.md
@@ -52,8 +52,8 @@ Control).
 
 ## How to Prevent
 
-Developers should implement some or all the following controls, d
-epending on the risk of the application:
+Developers should implement some or all the following controls, 
+depending on the risk of the application:
 
 -   Ensure all login, access control, and server-side input validation
     failures can be logged with sufficient user context to identify


### PR DESCRIPTION
Ensure the "depending" word is not split by a new line in markdown

This fixes the word appearing as "d epending" when viewing the HTML version