### PR TITLE
Fix typo in A07

### DIFF
--- a/2021/docs/A07_2021-Identification_and_Authentication_Failures.md
+++ b/2021/docs/A07_2021-Identification_and_Authentication_Failures.md
@@ -39,7 +39,7 @@ attacks. There may be authentication weaknesses if the application:
 
 -   Exposes Session IDs in the URL (e.g., URL rewriting).
 
--   Do not rotate Session IDs after successful login.
+-   Does not rotate Session IDs after successful login.
 
 -   Does not correctly invalidate Session IDs. User sessions or
     authentication tokens (mainly single sign-on (SSO) tokens) aren't


### PR DESCRIPTION
"Do not rotate" => "Does not rotate" so that the verb form matches the context (present tense with singular subject)