### PR TITLE
2021 french translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ $RECYCLE.BIN/
 # Visio autosave temporary files
 *.~vsd*
 2017/pt-pt/.vscode/settings.json
+
+# IDE folders
+.idea/

--- a/2021/docs/A01_2021-Broken_Access_Control.fr.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.fr.md
@@ -1,5 +1,192 @@
 # A01 2021 contrôle d'accès cassé
 
-## Facteurs
+## Factors
 
-Text en Francais
+| CWEs Mapped | Max Incidence Rate | Avg Incidence Rate | Max Coverage | Avg Coverage | Avg Weighted Exploit | Avg Weighted Impact | Total Occurrences | Total CVEs |
+|:-------------:|:--------------------:|:--------------------:|:--------------:|:--------------:|:----------------------:|:---------------------:|:-------------------:|:------------:|
+| 34          | 55.97%             | 3.81%              | 94.55%       | 47.72%       | 6.92                 | 5.93                | 318,487           | 19,013     |
+
+## Overview
+
+Moving up from the fifth position, 94% of applications were tested for
+some form of broken access control. Notable CWEs included are *CWE-200:
+Exposure of Sensitive Information to an Unauthorized Actor*, *CWE-201:
+Exposure of Sensitive Information Through Sent Data*, and *CWE-352:
+Cross-Site Request Forgery*.
+
+## Description
+
+Access control enforces policy such that users cannot act outside of
+their intended permissions. Failures typically lead to unauthorized
+information disclosure, modification, or destruction of all data or
+performing a business function outside the user's limits. Common access
+control vulnerabilities include:
+
+-   Bypassing access control checks by modifying the URL, internal
+    application state, or the HTML page, or simply using a custom API
+    attack tool.
+
+-   Allowing the primary key to be changed to another user's record,
+    permitting viewing or editing someone else's account.
+
+-   Elevation of privilege. Acting as a user without being logged in or
+    acting as an admin when logged in as a user.
+
+-   Metadata manipulation, such as replaying or tampering with a JSON
+    Web Token (JWT) access control token, or a cookie or hidden field
+    manipulated to elevate privileges or abusing JWT invalidation.
+
+-   CORS misconfiguration allows unauthorized API access.
+
+-   Force browsing to authenticated pages as an unauthenticated user or
+    to privileged pages as a standard user. Accessing API with missing
+    access controls for POST, PUT and DELETE.
+
+## How to Prevent
+
+Access control is only effective in trusted server-side code or
+server-less API, where the attacker cannot modify the access control
+check or metadata.
+
+-   Except for public resources, deny by default.
+
+-   Implement access control mechanisms once and re-use them throughout
+    the application, including minimizing CORS usage.
+
+-   Model access controls should enforce record ownership rather than
+    accepting that the user can create, read, update, or delete any
+    record.
+
+-   Unique application business limit requirements should be enforced by
+    domain models.
+
+-   Disable web server directory listing and ensure file metadata (e.g.,
+    .git) and backup files are not present within web roots.
+
+-   Log access control failures, alert admins when appropriate (e.g.,
+    repeated failures).
+
+-   Rate limit API and controller access to minimize the harm from
+    automated attack tooling.
+
+-   JWT tokens should be invalidated on the server after logout.
+
+Developers and QA staff should include functional access control unit
+and integration tests.
+
+## Example Attack Scenarios
+
+**Scenario #1:** The application uses unverified data in a SQL call that
+is accessing account information:
+
+> pstmt.setString(1, request.getParameter("acct"));
+>
+> ResultSet results = pstmt.executeQuery( );
+
+An attacker simply modifies the browser's 'acct' parameter to send
+whatever account number they want. If not correctly verified, the
+attacker can access any user's account.
+
+https://example.com/app/accountInfo?acct=notmyacct
+
+**Scenario #2:** An attacker simply forces browses to target URLs. Admin
+rights are required for access to the admin page.
+
+> https://example.com/app/getappInfo
+>
+> https://example.com/app/admin_getappInfo
+
+If an unauthenticated user can access either page, it's a flaw. If a
+non-admin can access the admin page, this is a flaw.
+
+## References
+
+-   [OWASP Proactive Controls: Enforce Access
+    Controls](https://owasp.org/www-project-proactive-controls/v3/en/c7-enforce-access-controls)
+
+-   [OWASP Application Security Verification Standard: V4 Access
+    Control](https://owasp.org/www-project-application-security-verification-standard)
+
+-   [OWASP Testing Guide: Authorization
+    Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
+
+-   [OWASP Cheat Sheet: Access Control]()
+
+-   [PortSwigger: Exploiting CORS
+    misconfiguration](https://portswigger.net/blog/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
+
+## List of Mapped CWEs
+
+CWE-22 Improper Limitation of a Pathname to a Restricted Directory
+('Path Traversal')
+
+CWE-23 Relative Path Traversal
+
+CWE-35 Path Traversal: '.../...//'
+
+CWE-59 Improper Link Resolution Before File Access ('Link Following')
+
+CWE-200 Exposure of Sensitive Information to an Unauthorized Actor
+
+CWE-201 Exposure of Sensitive Information Through Sent Data
+
+CWE-219 Storage of File with Sensitive Data Under Web Root
+
+CWE-264 Permissions, Privileges, and Access Controls (should no longer
+be used)
+
+CWE-275 Permission Issues
+
+CWE-276 Incorrect Default Permissions
+
+CWE-284 Improper Access Control
+
+CWE-285 Improper Authorization
+
+CWE-352 Cross-Site Request Forgery (CSRF)
+
+CWE-359 Exposure of Private Personal Information to an Unauthorized
+Actor
+
+CWE-377 Insecure Temporary File
+
+CWE-402 Transmission of Private Resources into a New Sphere ('Resource
+Leak')
+
+CWE-425 Direct Request ('Forced Browsing')
+
+CWE-441 Unintended Proxy or Intermediary ('Confused Deputy')
+
+CWE-497 Exposure of Sensitive System Information to an Unauthorized
+Control Sphere
+
+CWE-538 Insertion of Sensitive Information into Externally-Accessible
+File or Directory
+
+CWE-540 Inclusion of Sensitive Information in Source Code
+
+CWE-548 Exposure of Information Through Directory Listing
+
+CWE-552 Files or Directories Accessible to External Parties
+
+CWE-566 Authorization Bypass Through User-Controlled SQL Primary Key
+
+CWE-601 URL Redirection to Untrusted Site ('Open Redirect')
+
+CWE-639 Authorization Bypass Through User-Controlled Key
+
+CWE-651 Exposure of WSDL File Containing Sensitive Information
+
+CWE-668 Exposure of Resource to Wrong Sphere
+
+CWE-706 Use of Incorrectly-Resolved Name or Reference
+
+CWE-862 Missing Authorization
+
+CWE-863 Incorrect Authorization
+
+CWE-913 Improper Control of Dynamically-Managed Code Resources
+
+CWE-922 Insecure Storage of Sensitive Information
+
+CWE-1275 Sensitive Cookie with Improper SameSite Attribute

--- a/2021/docs/A01_2021-Broken_Access_Control.fr.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.fr.md
@@ -1,4 +1,4 @@
-# A01 2021 contrôle d'accès cassé
+# A01:2021 - Contrôle d'accès rompu
 
 ## Factors
 

--- a/2021/docs/index.fr.md
+++ b/2021/docs/index.fr.md
@@ -1,3 +1,337 @@
 # Introduction a OWASP Top 10 2021
 
-Français
+Welcome to the latest installment of the OWASP Top 10! The OWASP Top 10
+2021 is all-new, with a new graphic design and an available one-page
+infographic you can print or obtain from our home page.
+
+A huge thank you to everyone that contributed their time and data for
+this iteration. Without you, this installment would not happen. **THANK
+YOU**.
+
+## What's changed in the Top 10 for 2021
+
+There are three new categories, four categories with naming and scoping
+changes, and some consolidation in the Top 10 for 2021.
+
+<img src="./assets/image1.png" style="width:6.5in;height:1.78889in" alt="Mapping of the relationship between the Top 10 2017 and the new Top 10 2021" />
+
+**A01:2021-Broken Access Control** moves up from the fifth position; 94%
+of applications were tested for some form of broken access control. The
+34 CWEs mapped to Broken Access Control had more occurrences in
+applications than any other category.
+
+**A02:2021-Cryptographic Failures** shifts up one position to #2,
+previously known as *Sensitive Data Exposure,* which was broad symptom
+rather than a root cause. The renewed focus here is on failures related
+to cryptography which often leads to sensitive data exposure or system
+compromise.
+
+**A03:2021-Injection** slides down to the third position. 94% of the
+applications were tested for some form of injection, and the 33 CWEs
+mapped into this category have the second most occurrences in
+applications. Cross-site Scripting is now part of this category in this
+edition.
+
+**A04:2021-Insecure Design** is a new category for 2021, with a focus on
+risks related to design flaws. If we genuinely want to "move left" as an
+industry, it calls for more use of threat modeling, secure design
+patterns and principles, and reference architectures.
+
+**A05:2021-Security Misconfiguration** moves up from #6 in the previous
+edition; 90% of applications were tested for some form of
+misconfiguration. With more shifts into highly configurable software,
+it's not surprising to see this category move up. The former category
+for XML External Entities (XXE) is now part of this category.
+
+**A06:2021-Vulnerable and Outdated Components** was previously titled
+*Using Components with Known Vulnerabilities* and is #2 in the industry
+survey, but also had enough data to make the Top 10 via data analysis.
+This category moves up from #9 in 2017 and is a known issue that we
+struggle to test and assess risk. It is the only category not to have
+any CVEs mapped to the included CWEs, so a default exploit and impact
+weights of 5.0 are factored into their scores.
+
+**A07:2021-Identification and Authentication Failures** was previously
+*Broken Authentication* and is sliding down from the second position,
+and now includes CWEs that are more related to identification failures.
+This category is still an integral part of the Top 10, but the increased
+availability of standardized frameworks seems to be helping.
+
+**A08:2021-Software and Data Integrity Failures** is a new category for
+2021, focusing on making assumptions related to software updates,
+critical data, and CI/CD pipelines without verifying integrity. One of
+the highest weighted impacts from CVE/CVSS data mapped to the 10 CWEs in
+this category. Insecure Deserialization from 2017 is now a part of this
+larger category.
+
+**A09:2021-Security Logging and Monitoring Failures** was previously
+*Insufficient Logging &* Monitoring and is added from the industry
+survey (#3), moving up from #10 previously. This category is expanded to
+include more types of failures, is challenging to test for, and isn't
+well represented in the CVE/CVSS data. However, failures in this
+category can directly impact visibility, incident alerting, and
+forensics.
+
+**A10:2021-Server-Side Request Forgery** is added from the industry
+survey (#1). The data shows a relatively low incidence rate with above
+average testing coverage, along with above-average ratings for Exploit
+and Impact potential. This category represents the scenario where the
+industry professionals are telling us this is important, even though
+it's not illustrated in the data at this time.
+
+## Methodology
+
+This installment of the Top 10 is more data-driven than ever but not
+blindly data-driven. We selected eight of the ten categories from
+contributed data and two categories from an industry survey at a high
+level. We do this for a fundamental reason, looking at the contributed
+data is looking into the past. AppSec researchers take time to find new
+vulnerabilities and new ways to test for them. It takes time to
+integrate these tests into tools and processes. By the time we can
+reliably test a weakness at scale, years have likely passed. To balance
+that view, we use an industry survey to ask people on the front lines
+what they see as essential weaknesses that the data may not show yet.
+
+There are a few critical changes that we adopted to continue to mature
+the Top 10.
+
+### How the categories are structured
+
+A few categories have changed from the previous installment of the OWASP
+Top Ten. Here is a high-level summary of the category changes.
+
+Previous data collection efforts were focused on a prescribed subset of
+approximately 30 CWEs with a field asking for additional findings. We
+learned that organizations would primarily focus on just those 30 CWEs
+and rarely add additional CWEs that they saw. In this iteration, we
+opened it up and just asked for data, with no restriction on CWEs. We
+asked for the number of applications tested for a given year (starting
+in 2017), and the number of applications with at least one instance of a
+CWE found in testing. This format allows us to track how prevalent each
+CWE is within the population of applications. We ignore frequency for
+our purposes; while it may be necessary for other situations, it only
+hides the actual prevalence in the application population. Whether an
+application has four instances of a CWE or 4,000 instances is not part
+of the calculation for the Top 10. We went from approximately 30 CWEs to
+almost 400 CWEs to analyze in the dataset. We plan to do additional data
+analysis as a supplement in the future. This significant increase in the
+number of CWEs necessitates changes to how the categories are
+structured.
+
+We spent several months grouping and categorizing CWEs and could have
+continued for additional months. We had to stop at some point. There are
+both *root cause* and *symptom* types of CWEs, where *root cause* types
+are like "Cryptographic Failure" and "Misconfiguration" contrasted to
+*symptom* types like "Sensitive Data Exposure" and "Denial of Service."
+We decided to focus on the root cause whenever possible as it's more
+logical for providing identification and remediation guidance. Focusing
+on the root cause over the symptom isn't a new concept; the Top Ten has
+been a mix of *symptom* and *root cause*. CWEs are also a mix of
+*symptom* and *root cause*; we are simply being more deliberate about it
+and calling it out. There is an average of 19.6 CWEs per category in
+this installment, with the lower bounds at 1 CWE for
+*A10:2021-Server-Side Request Forgery (SSRF)* to 40 CWEs in
+*A04:2021-Insecure Design*. This updated category structure offers
+additional training benefits as companies can focus on CWEs that make
+sense for a language/framework.
+
+### How the data is used for selecting categories
+
+In 2017, we selected categories by incidence rate to determine
+likelihood, then ranked them by team discussion based on decades of
+experience for Exploitability, Detectability (also likelihood), and
+Technical Impact. For 2021, we want to use data for Exploitability and
+Impact if possible.
+
+We downloaded OWASP Dependency Check and extracted the CVSS Exploit, and
+Impact scores grouped by related CWEs. It took a fair bit of research
+and effort as all the CVEs have CVSSv2 scores, but there are flaws in
+CVSSv2 that CVSSv3 should address. After a certain point in time, all
+CVEs are assigned a CVSSv3 score as well. Additionally, the scoring
+ranges and formulas were updated between CVSSv2 and CVSSv3.
+
+In CVSSv2, both Exploit and Impact could be up to 10.0, but the formula
+would knock them down to 60% for Exploit and 40% for Impact. In CVSSv3,
+the theoretical max was limited to 6.0 for Exploit and 4.0 for Impact.
+With the weighting considered, the Impact scoring shifted higher, almost
+a point and a half on average in CVSSv3, and exploitability moved nearly
+half a point lower on average.
+
+There are 125k records of a CVE mapped to a CWE in the NVD data
+extracted from OWASP Dependency Check, and there are 241 unique CWEs
+mapped to a CVE. 62k CWE maps have a CVSSv3 score, which is
+approximately half of the population in the data set.
+
+For the Top Ten, we calculated average exploit and impact scores in the
+following manner. We grouped all the CVEs with CVSS scores by CWE and
+weighted both exploit and impact scored by the percentage of the
+population that had CVSSv3 + the remaining population of CVSSv2 scores
+to get an overall average. We mapped these averages to the CWEs in the
+dataset to use as Exploit and Impact scoring for the other half of the
+risk equation.
+
+## Why not just pure statistical data?
+
+The results in the data are primarily limited to what we can test for in
+an automated fashion. Talk to a seasoned AppSec professional, and they
+will tell you about stuff they find and trends they see that aren't yet
+in the data. It takes time for people to develop testing methodologies
+for certain vulnerability types and then more time for those tests to be
+automated and run against a large population of applications. Everything
+we find is looking back in the past and might be missing trends from the
+last year, which are not present in the data.
+
+Therefore, we only pick eight of ten categories from the data because
+it's incomplete. The other two categories are from the industry survey.
+It allows the practitioners on the front lines to vote for what they see
+as the highest risks that might not be in the data (and may never be
+expressed in data).
+
+## Why incidence rate instead of frequency?
+
+There are three primary sources of data. We identify them as
+Human-assisted Tooling (HaT), Tool-assisted Human (TaH), and raw
+Tooling.
+
+Tooling and HaT are high-frequency finding generators. Tools will look
+for specific vulnerabilities and tirelessly attempt to find every
+instance of that vulnerability and will generate high finding counts for
+some vulnerability types. Look at Cross-Site Scripting, which is
+typically one of two flavors: it's either a more minor, isolated mistake
+or a systemic issue. When it's a systemic issue, the finding counts can
+be in the thousands for an application. This high frequency drowns out
+most other vulnerabilities found in reports or data.
+
+TaH, on the other hand, will find a broader range of vulnerability types
+but at a much lower frequency due to time constraints. When humans test
+an application and see something like Cross-Site Scripting, they will
+typically find three or four instances and stop. They can determine a
+systemic finding and write it up with a recommendation to fix on an
+application-wide scale. There is no need (or time) to find every
+instance.
+
+Suppose we take these two distinct data sets and try to merge them on
+frequency. In that case, the Tooling and HaT data will drown the more
+accurate (but broad) TaH data and is a good part of why something like
+Cross-Site Scripting has been so highly ranked in many lists when the
+impact is generally low to moderate. It's because of the sheer volume of
+findings. (Cross-Site Scripting is also reasonably easy to test for, so
+there are many more tests for it as well).
+
+In 2017, we introduced using incidence rate instead to take a fresh look
+at the data and cleanly merge Tooling and HaT data with TaH data. The
+incidence rate asks what percentage of the application population had at
+least one instance of a vulnerability type. We don't care if it was
+one-off or systemic. That's irrelevant for our purposes; we just need to
+know how many applications had at least one instance, which helps
+provide a clearer view of the testing is findings across multiple
+testing types without drowning the data in high-frequency results.
+
+## What is your data collection and analysis process?
+
+We formalized the OWASP Top 10 data collection process at the Open
+Security Summit in 2017. OWASP Top 10 leaders and the community spent
+two days working out formalizing a transparent data collection process.
+The 2021 edition is the second time we have used this methodology.
+
+We publish a call for data through social media channels available to
+us, both project and OWASP. On the [OWASP Project
+page](https://owasp.org/www-project-top-ten/#div-data_2020), we list the
+data elements and structure we are looking for and how to submit them.
+In the [GitHub
+project](https://github.com/OWASP/Top10/tree/master/2020/Data), we have
+example files that serve as templates. We work with organizations as
+needed to help figure out the structure and mapping to CWEs.
+
+We get data from organizations that are testing vendors by trade, bug
+bounty vendors, and organizations that contribute internal testing data.
+Once we have the data, we load it together and run a fundamental
+analysis of what CWEs map to risk categories. There is overlap between
+some CWEs, and others are very closely related (ex. Cryptographic
+vulnerabilities). Any decisions related to the raw data submitted are
+documented and published to be open and transparent with how we
+normalized the data.
+
+We look at the eight categories with the highest incidence rates for
+inclusion in the Top 10. We also look at the industry survey results to
+see which ones may already be present in the data. The top two votes
+that aren't already present in the data will be selected for the other
+two places in the Top 10. Once all ten were selected, we applied
+generalized factors for exploitability and impact; to help rank the Top
+10 in order.
+
+## Data Factors
+
+There are data factors that are listed for each of the Top 10
+Categories, here is what they mean:
+
+-   *CWEs Mapped*: The number of CWEs mapped to a category by the Top 10
+    team.
+
+-   *Incidence Rate*: Incidence rate is the percentage of applications
+    vulnerable to that CWE from the population tested by that org for
+    that year.
+
+-   (Testing) *Coverage*: The percentage of applications tested by all
+    organizations for a given CWE.
+
+-   *Weighted Exploit*: The Exploit sub-score from CVSSv2 and CVSSv3
+    scores assigned to CVEs mapped to CWEs, normalized, and placed on a
+    10pt scale.
+
+-   *Weighted Impact*: The Impact sub-score from CVSSv2 and CVSSv3
+    scores assigned to CVEs mapped to CWEs, normalized, and placed on a
+    10pt scale.
+
+-   *Total Occurrences*: Total number of applications found to have the
+    CWEs mapped to a category.
+
+-   *Total CVEs*: Total number of CVEs in the NVD DB that were mapped to
+    the CWEs mapped to a category.
+
+## Category Relationships from 2017
+
+There has been a lot of talk about the overlap between the Top Ten
+risks. By the definition of each (list of CWEs included), there really
+isn't any overlap. However, conceptually, there can be overlap or
+interactions based on the higher-level naming. Venn diagrams are many
+times used to show overlap like this.
+
+<img src="./assets/image2.png" style="width:4.31736in;height:3.71339in" alt="Diagram Description automatically generated" />
+
+The Venn diagram above represents the interactions between the Top Ten
+2017 risk categories. While doing so, a couple of essential points
+became obvious:
+
+1.  One could argue that Cross-Site Scripting ultimately belongs within
+    Injection as it's essentially Content Injection. Looking at the 2021
+    data, it became even more evident that XSS needed to move into
+    Injection.
+
+2.  The overlap is only in one direction. We will often classify a
+    vulnerability by the end manifestation or "symptom," not the
+    (potentially deep) root cause. For instance, "Sensitive Data
+    Exposure" may have been the result of a "Security Misconfiguration";
+    however, you won't see it in the other direction. As a result,
+    arrows are drawn in the interaction zones to indicate which
+    direction it occurs.
+
+3.  Sometimes these diagrams are drawn with everything in *A06:2021
+    Using Components with Known Vulnerabilities*. While some of these
+    risk categories may be the root cause of third-party
+    vulnerabilities, they are generally managed differently and with
+    different responsibilities. The other types are typically
+    representing first-party risks.
+
+# Thank you to our data contributors
+
+The following organizations (along with some anonymous donors) kindly
+donated data for over 500,000 applications to make this the largest and
+most comprehensive application security data set. Without you, this
+would not be possible.
+
+| | | | |
+| :---: | :---: | :---: | :---: |
+| AppSec Labs | GitLab | Micro Focus | Sqreen |
+| Cobalt.io | HackerOne | PenTest-Tools | Veracode |
+| Contrast Security | HCL Technologies | Probely | WhiteHat (NTT) |

--- a/2021/docs/index.fr.md
+++ b/2021/docs/index.fr.md
@@ -1,4 +1,4 @@
-# Introduction a OWASP Top 10 2021
+# Introduction à l'OWASP Top 10 2021
 
 Welcome to the latest installment of the OWASP Top 10! The OWASP Top 10
 2021 is all-new, with a new graphic design and an available one-page

--- a/2021/mkdocs.yml
+++ b/2021/mkdocs.yml
@@ -43,8 +43,19 @@ plugins:
           About: À propos
           How to use the OWASP Top 10 as a standard: Comment utiliser le Top 10 OWASP comme standard
           How to start an AppSec program with the OWASP Top 10: Comment démarrer un programme AppSec avec le Top 10 OWASP
+          About OWASP: À propos de l'OWASP
           Top 10 List: Liste top 10
-          A01 Broken Access Control: A01 Contrôle d'accès cassé
+          A01 Broken Access Control: A01 Contrôle d'accès rompu
+          A02 Cryptographic Failures: A02 Défaillances cryptographiques
+          A03 Injection: A03 Injection
+          A04 Insecure Design: A04 Conception fragile
+          A05 Security Misconfiguration: A05 Mauvaise configuration de sécurité
+          A06 Vulnerable and Outdated Components: A06 Composants vulnérables et obsolètes
+          A07 Identification and Authentication Failures: A07 Identification et authentification de mauvaise qualité
+          A08 Software and Data Integrity Failures: A08 Manque d'intégrité des données et du logiciel
+          A09 Security Logging and Monitoring Failures: A09 Carence des systèmes de contrôle et de journalisation
+          A10 Server Side Request Forgery (SSRF): A10 Falsification de requête côté serveur
+          Next Steps: Étapes suivantes
         it:
           About: Riguardo ad OWASP
           How to use the OWASP Top 10 as a standard: Come utilizzare l'OWASP Top 10 come standard


### PR DESCRIPTION
Hello,

I am opening this PR to start the french translation of the OWASP Top Ten 2021.

Currently, the OWASP Top Ten 2021 website display the french language with some regressions, index and A01 are missing content.

As of now this PR :
* Set temporarily the content of the index and A01 french pages to the English version (with the french title)
* Translate the main menu

Therefore, if the website is published as is displaying a french translation available in the top right menu, I think it would be preferable to have at least these changes incorporated so untranslated content is at least displayed in English.

If maintainers agree with a progressive and partial translation, do not hesitate to merge this PR and incorporate current changes. I will then open new PRs to continue translating the document. Therefore, I will handle any comment in this PR before committing any new translation so this PR is always in a "production ready" status.

I'm also following the OWASP Slack #top-10-translations channel. If anyone want to join in the french translation. Do not hesitate to contact me and we can work on it together. :slightly_smiling_face: 