### PR TITLE
Fixed/added links

### DIFF
--- a/2021/docs/A03_2021-Injection.md
+++ b/2021/docs/A03_2021-Injection.md
@@ -183,4 +183,4 @@ Downstream Component ('Injection')](https://cwe.mitre.org/data/definitions/74.ht
 
 [CWE-652 Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')](https://cwe.mitre.org/data/definitions/652.html)
 
-[CWE-917 Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')] (https://cwe.mitre.org/data/definitions/917.html)
+[CWE-917 Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')](https://cwe.mitre.org/data/definitions/917.html)

--- a/2021/docs/A05_2021-Security_Misconfiguration.md
+++ b/2021/docs/A05_2021-Security_Misconfiguration.md
@@ -107,7 +107,7 @@ sensitive data stored within cloud storage to be accessed.
 
 -   [OWASP Testing Guide: Testing for Error Codes](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/01-Testing_For_Improper_Error_Handling)
 
--   Application Security Verification Standard V19 Configuration
+-   [Application Security Verification Standard V19 Configuration](https://owasp-aasvs.readthedocs.io/en/latest/v19.html)
 
 -   [NIST Guide to General Server
     Hardening](https://csrc.nist.gov/publications/detail/sp/800-123/final)

--- a/2021/docs/A09_2021-Security_Logging_and_Monitoring_Failures.md
+++ b/2021/docs/A09_2021-Security_Logging_and_Monitoring_Failures.md
@@ -119,7 +119,7 @@ result by the privacy regulator.
     Application Logging Vocabulary](https://cheatsheetseries.owasp.org/cheatsheets/Application_Logging_Vocabulary_Cheat_Sheet.html)
 
 -   [OWASP Cheat Sheet:
-    Logging](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html))   
+    Logging](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)
 
 -   [Data Integrity: Recovering from Ransomware and Other Destructive
     Events](https://csrc.nist.gov/publications/detail/sp/1800-11/final)


### PR DESCRIPTION
Noticed a rogue bracket in A09:2021 – Security Logging and Monitoring Failures.

I had a read-over and fixed/added other links.