### PR TITLE
Fix typo in A00_2021_Introduction.md

### DIFF
--- a/2021/docs/A00_2021_Introduction.md
+++ b/2021/docs/A00_2021_Introduction.md
@@ -27,7 +27,7 @@ There are three new categories, four categories with naming and scoping changes,
 
 ## Methodology
 
-This installment of the Top 10 is more data-driven than ever but not blindly data-driven. We selected eight of the ten categories from contributed data and two categories from the Top 10 community survey at a high level. We do this for a fundamental reason, looking at the contributed data is looking into the past. AppSec researchers take time to find new vulnerabilities and new ways to test for them. It takes time to integrate these tests into tools and processes. By the time we can reliably test a weakness at scale, years have likely passed. To balance that view, we use an community survey to ask application security and development experts on the front lines what they see as essential weaknesses that the data may not show yet.
+This installment of the Top 10 is more data-driven than ever but not blindly data-driven. We selected eight of the ten categories from contributed data and two categories from the Top 10 community survey at a high level. We do this for a fundamental reason, looking at the contributed data is looking into the past. AppSec researchers take time to find new vulnerabilities and new ways to test for them. It takes time to integrate these tests into tools and processes. By the time we can reliably test a weakness at scale, years have likely passed. To balance that view, we use a community survey to ask application security and development experts on the front lines what they see as essential weaknesses that the data may not show yet.
 
 There are a few critical changes that we adopted to continue to mature the Top 10.
 


### PR DESCRIPTION
We should use 'a' when the indefinite article comes before a word beginning with a consonant sound.
'an community survey' => 'a community survey'

Ref: https://www.grammarly.com/blog/indefinite-articles-a-and-an/