### PR TITLE
Update A02_2021-Cryptographic_Failures.md

### DIFF
--- a/2021/docs/A02_2021-Cryptographic_Failures.md
+++ b/2021/docs/A02_2021-Cryptographic_Failures.md
@@ -171,6 +171,8 @@ salted.
 
 ## List of Mapped CWEs
 
+[CWE-259 Use of Hard-coded Password](https://cwe.mitre.org/data/definitions/259.html)
+
 [CWE-261 Weak Encoding for Password](https://cwe.mitre.org/data/definitions/261.html)
 
 [CWE-296 Improper Following of a Certificate's Chain of Trust](https://cwe.mitre.org/data/definitions/296.html)


### PR DESCRIPTION
Just adding the CWE-259, because it was mentioned on overview as notable, but it's missing from Mapped CWE list.