### PR TITLE
Update A04_2021-Insecure_Design.md

### DIFF
--- a/2021/docs/A04_2021-Insecure_Design.md
+++ b/2021/docs/A04_2021-Insecure_Design.md
@@ -85,7 +85,7 @@ rejected such transactions.
 
 -   [OWASP SAMM: Design:Threat Assessment](https://owaspsamm.org/model/design/threat-assessment/) 
 
--   [NIST – Guidelines on Minimum Standards for Developer Verification of Software](https://www.nist.gov/system/files/documents/2021/07/13/Developer%20Verification%20of%20Software.pdf)
+-   [NIST – Guidelines on Minimum Standards for Developer Verification of Software](https://www.nist.gov/publications/guidelines-minimum-standards-developer-verification-software)
 
 -   [The Threat Modeling Manifesto](https://threatmodelingmanifesto.org)
 


### PR DESCRIPTION
Fixed broken NIST link. Also linked to overview page rather than direct download.