### PR TITLE
Update A06_2021-Vulnerable_and_Outdated_Components.md

### DIFF
--- a/2021/docs/A06_2021-Vulnerable_and_Outdated_Components.md
+++ b/2021/docs/A06_2021-Vulnerable_and_Outdated_Components.md
@@ -11,7 +11,7 @@
 It was #2 from the Top 10 community survey but also had enough data to make the
 Top 10 via data. Vulnerable Components are a known issue that we
 struggle to test and assess risk and is the only category to not have
-any Common Weakness Enumerations (CWEs) mapped to the included CWEs, so a default exploits/impact
+any Common Vulnerability and Exposures (CVEs) mapped to the included CWEs, so a default exploits/impact
 weight of 5.0 is used. Notable CWEs included are *CWE-1104: Use of
 Unmaintained Third-Party Components* and the two CWEs from Top 10 2013
 and 2017.


### PR DESCRIPTION
As pointed out in the included issue, there is a typo on the A06 page. This change makes it consistent with what was written in the [index.md](/OWASP/Top10/blob/master/2021/docs/index.md).

![image](https://user-images.githubusercontent.com/20944885/156200913-ca80cc43-cf96-44b3-a136-4a346460a649.png)

Resolves #678.
