### PR TITLE
Remove deprecated Reference link from A01_2021-Broken_Access_Control.md

### DIFF
--- a/2021/docs/A01_2021-Broken_Access_Control.ar.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.ar.md
@@ -79,8 +79,6 @@ https://example.com/app/accountInfo?acct=notmyacct
 
 -   [OWASP Testing Guide: Authorization Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS

--- a/2021/docs/A01_2021-Broken_Access_Control.fr.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.fr.md
@@ -72,8 +72,6 @@ Si un utilisateur non-authentifié peut accéder à l'une des pages, c'est une f
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS

--- a/2021/docs/A01_2021-Broken_Access_Control.id.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.id.md
@@ -80,8 +80,6 @@ Jika sebuah user yang belum di autentikasi dapat mengakses kedua page tersebut m
 - [OWASP Testing Guide: Authorization
   Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
-- [OWASP Cheat Sheet: Access Control]()
-
 - [PortSwigger: Exploiting CORS
   misconfiguration](https://portswigger.net/blog/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
 

--- a/2021/docs/A01_2021-Broken_Access_Control.it.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.it.md
@@ -113,8 +113,6 @@ Se un utente non autenticato può accedere a una delle due pagine, è una falla.
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS

--- a/2021/docs/A01_2021-Broken_Access_Control.ja.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.ja.md
@@ -276,8 +276,6 @@ non-admin can access the admin page, this is a flaw.
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control]()
-
 -   [PortSwigger: Exploiting CORS
     misconfiguration](https://portswigger.net/blog/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
 

--- a/2021/docs/A01_2021-Broken_Access_Control.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.md
@@ -121,8 +121,6 @@ non-admin can access the admin page, this is a flaw.
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS

--- a/2021/docs/A01_2021-Broken_Access_Control.pt_BR.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.pt_BR.md
@@ -125,8 +125,6 @@ Se um não administrador pode acessar a página de administração, isso é uma 
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS

--- a/2021/docs/A01_2021-Broken_Access_Control.zh_TW.md
+++ b/2021/docs/A01_2021-Broken_Access_Control.zh_TW.md
@@ -80,8 +80,6 @@ https://example.com/app/accountInfo?acct=notmyacct
 -   [OWASP Testing Guide: Authorization
     Testing](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/README)
 
--   [OWASP Cheat Sheet: Access Control](https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html)
-
 -   [OWASP Cheat Sheet: Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)
 
 -   [PortSwigger: Exploiting CORS


### PR DESCRIPTION
There was a deprecated link (https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html) in A01_2021-Broken_Access_Control.md and its translations. This link has been removed and A01_2021 along with its translations have been updated.