### PR TITLE
Add language codes to the menue

### DIFF
--- a/2021/mkdocs.yml
+++ b/2021/mkdocs.yml
@@ -38,17 +38,16 @@ plugins:
   - i18n:
       default_language: en
       languages:
-        en: English
-        ar: العربية
-        es: Español
-        fr: Français
-        id: Indonesian
-        it: Italiano
-        ja: 日本語
-        pt_BR: Português (Brasil)
-        zh_CN: 简体中文
-        zh_TW: 繁體中文
+        en: en - English
+        ar: ar - العربية
+        es: es - Español
+        fr: fr - Français
+        id: id - Indonesian
+        it: it - Italiano
+        ja: ja - 日本語
 #        pt_BR: pt_BR - Português (Brasil) # not finished yet
+        zh_CN: zh_CN - 简体中文
+        zh_TW: zh_TW - 繁體中文
 
       nav_translations:
         ar:


### PR DESCRIPTION
Mkdocs seems not to keep the order of the languages.
Added the languages codes to get it clearer.