### PR TITLE
Deactivate broken cheat sheet links

### DIFF
--- a/2021/docs/A04_2021-Insecure_Design.ar.md
+++ b/2021/docs/A04_2021-Insecure_Design.ar.md
@@ -38,7 +38,7 @@
 
 ## المصادر
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.es.md
+++ b/2021/docs/A04_2021-Insecure_Design.es.md
@@ -57,7 +57,7 @@ entusiastas que no pueden obtener estas tarjetas a ningún precio. El diseño cu
 
 ## Referencias
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.fr.md
+++ b/2021/docs/A04_2021-Insecure_Design.fr.md
@@ -48,7 +48,7 @@ Un logiciel sécurisé nécessite un cycle de vie de développement sécurisé, 
 
 ## Références
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.it.md
+++ b/2021/docs/A04_2021-Insecure_Design.it.md
@@ -74,7 +74,7 @@ respingere tali transazioni.
 
 ## Riferimenti
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.ja.md
+++ b/2021/docs/A04_2021-Insecure_Design.ja.md
@@ -85,7 +85,7 @@
 
 ## 参考資料
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 
@@ -260,7 +260,7 @@ rejected such transactions.
 
 ## References
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.md
+++ b/2021/docs/A04_2021-Insecure_Design.md
@@ -79,7 +79,7 @@ rejected such transactions.
 
 ## References
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A04_2021-Insecure_Design.pt_BR.md
+++ b/2021/docs/A04_2021-Insecure_Design.pt_BR.md
@@ -111,7 +111,7 @@ podem identificar compras não autênticas e rejeitar tais transações.
 
 ## Referências
 
--   [OWASP Cheat Sheet: Secure Design Principles](Coming Soon)
+-   OWASP Cheat Sheet: Secure Design Principles (Coming Soon)
 
 -   [OWASP SAMM: Design:Security Architecture](https://owaspsamm.org/model/design/security-architecture/)
 

--- a/2021/docs/A08_2021-Software_and_Data_Integrity_Failures.ar.md
+++ b/2021/docs/A08_2021-Software_and_Data_Integrity_Failures.ar.md
@@ -39,9 +39,9 @@
 
 ## المصادر
 
--   [OWASP Cheat Sheet: Software Supply Chain Security](Coming Soon)
+-   OWASP Cheat Sheet: Software Supply Chain Security (Coming Soon)
 
--   [OWASP Cheat Sheet: Secure build and deployment](Coming Soon)
+-   OWASP Cheat Sheet: Secure build and deployment (Coming Soon)
 
 -    [OWASP Cheat Sheet: Infrastructure as Code](https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html) 
  


### PR DESCRIPTION
Fixes #723 by removing square brackets around title of cheat sheets that aren't published yet so Markdown doesn't interpret them as links to a URL called "Coming Soon"

Signed-off-by: Shlomo Heigh <shlomo.heigh@cyberark.com>