### PR TITLE
Update year to 2023

### DIFF
--- a/2021/docs/A00-about-owasp.md
+++ b/2021/docs/A00-about-owasp.md
@@ -32,4 +32,4 @@ Come join us!
 
 ![license](assets/license.png)
 
-Copyright © 2003-2022 The OWASP™ Foundation. This document is released under the Creative Commons Attribution Share-Alike 4.0 license. For any reuse or distribution, you must make it clear to others the license terms of this work.
+Copyright © 2003-2023 The OWASP™ Foundation. This document is released under the Creative Commons Attribution Share-Alike 4.0 license. For any reuse or distribution, you must make it clear to others the license terms of this work.


### PR DESCRIPTION
Hey there!

This "one line PR" updates the 'About OWASP' page year from 2022 to 2023.