### PR TITLE
Update link in A06_2021-Vulnerable_and_Outdated_Components.md

### DIFF
--- a/2021/docs/A06_2021-Vulnerable_and_Outdated_Components.md
+++ b/2021/docs/A06_2021-Vulnerable_and_Outdated_Components.md
@@ -62,8 +62,8 @@ There should be a patch management process in place to:
 
 -   Only obtain components from official sources over secure links.
     Prefer signed packages to reduce the chance of including a modified,
-    malicious component (See A08:2021-Software and Data Integrity
-    Failures).
+    malicious component (see [A08:2021-Software and Data Integrity
+    Failures](A08_2021-Software_and_Data_Integrity_Failures.md)).
 
 -   Monitor for libraries and components that are unmaintained or do not
     create security patches for older versions. If patching is not


### PR DESCRIPTION
This fixes the link in the English version of [A06:2021 – Vulnerable and Outdated Components](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/)

Part of #775 