### PR TITLE
Fix percentage typo in A05_2021-Security_Misconfiguration.md

### DIFF
--- a/2021/docs/A05_2021-Security_Misconfiguration.md
+++ b/2021/docs/A05_2021-Security_Misconfiguration.md
@@ -9,7 +9,7 @@
 ## Overview
 
 Moving up from #6 in the previous edition, 90% of applications were
-tested for some form of misconfiguration, with an average incidence rate of 4.%, and over 208k occurrences of a Common Weakness Enumeration (CWE) in this risk category. With more shifts into highly configurable software, it's not surprising to see this category move up.
+tested for some form of misconfiguration, with an average incidence rate of 4.51%, and over 208k occurrences of a Common Weakness Enumeration (CWE) in this risk category. With more shifts into highly configurable software, it's not surprising to see this category move up.
 Notable CWEs included are *CWE-16 Configuration* and *CWE-611 Improper
 Restriction of XML External Entity Reference*.
 


### PR DESCRIPTION
4.51% average incident rate was left as "4.%" in paragraph. This fixes it.