### PR TITLE
requirements.txt: limit mkdocs-static-i18n version from 0.40 to 0.56

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mkdocs
 mkdocs-material
 pymdown-extensions
 Pygments
-mkdocs-static-i18n
+mkdocs-static-i18n<=0.56,>=0.40


### PR DESCRIPTION
*warning* Version 1.0.0 of this plugin brings breaking changes to the configuration format, e.g. mkdocs.yml file, see https://pypi.org/project/mkdocs-static-i18n/1.0.0/