### PR TITLE
Fix: add space in Markdown heading for proper rendering

### DIFF
--- a/osib/docs/A01_2021-Broken_Access_Control.md
+++ b/osib/docs/A01_2021-Broken_Access_Control.md
@@ -6,7 +6,7 @@ lang:    "en"
 ---
 {%- set parent = extra.osib.document ~ "." ~ extra.osib.version -%}
 {%- set osib   = parent ~ ".1" -%}
-#A01:2021 – Broken Access Control     ![icon](assets/TOP_10_Icons_Final_Broken_Access_Control.png){: style="height:80px;width:80px" align="right"} {{ osib_anchor(osib=osib, id=id, name="Broken Access Control", lang=lang, source=source, parent=parent, predecessor=extra.osib.document ~ ".2017.5" ) }}
+# A01:2021 – Broken Access Control     ![icon](assets/TOP_10_Icons_Final_Broken_Access_Control.png){: style="height:80px;width:80px" align="right"} {{ osib_anchor(osib=osib, id=id, name="Broken Access Control", lang=lang, source=source, parent=parent, predecessor=extra.osib.document ~ ".2017.5" ) }}
 
 
 ## Factors {{ osib_anchor(osib=osib ~ ".factors", id=id ~ "-factors", name=title ~ ": Factors", lang=lang, source=source ~ "#" ~ id, parent=osib) }}


### PR DESCRIPTION

This pull request fixes a minor Markdown formatting issue in the A01:2021 heading.

### Details of Changes
- Added a missing space after `#` in the heading:
  - Before: `#A01:2021 – Broken Access Control`
  - After:  `# A01:2021 – Broken Access Control`
What is the need?
Without the space, the heading was not rendering correctly in Markdown.  
This fix ensures proper formatting and consistent readability.
Checklist
1) Corrected heading spacing
2)Verified Markdown renders properly
![IMAGE 2025-09-23 11:35:12](https://github.com/user-attachments/assets/35b32f48-9508-4717-bca3-b6dbc56aa33c)

