### PR TITLE
Added blank space on software supply chain security guidelines

### DIFF
--- a/2021/docs/en/2025/A03_2025-Software_Supply_Chain_Failures.md
+++ b/2021/docs/en/2025/A03_2025-Software_Supply_Chain_Failures.md
@@ -79,8 +79,6 @@ You are likely vulnerable if:
 
 There should be a patch management process in place to:
 
-
-
 * Know your Software Bill of Materials (SBOM) of your entire software and manage the SBOM-dictionary centrally.
 * Track not just your own dependencies, but their (transitive) dependencies, and so on.
 * Remove unused dependencies, unnecessary features, components, files, and documentation. Attack surface reduction.
@@ -94,6 +92,7 @@ There should be a patch management process in place to:
 
 
 There should be a change management process or tracking system in place to track changes to:
+
 * Your CI/CD settings (all build tools and pipeline)
 * Your code repository
 * Sandbox areas
@@ -106,6 +105,7 @@ There should be a change management process or tracking system in place to track
 
 
 Harden the following systems, which includes enabling MFA and locking down IAM:
+
 * Your code repository (which includes not checking in secrets, protecting branches, backups)
 * Developer workstations (regular patching, MFA, monitoring, and more)
 * Your build server & CI/CD (separation of duties, access control, signed builds, environment-scoped secrets, tamper-evident logs, more)


### PR DESCRIPTION
Previously it's not displayed as list.