### PR TITLE
Fix A10 background formatting

### DIFF
--- a/2021/docs/en/2025/A10_2025-Mishandling_of_Exceptional_Conditions.md
+++ b/2021/docs/en/2025/A10_2025-Mishandling_of_Exceptional_Conditions.md
@@ -6,7 +6,7 @@
 
 Mishandling of Exceptional Conditions is a new category for 2025. This category contains 24 CWEs and focuses on improper error handling, logical errors, failing open, and other related scenarios stemming from abnormal conditions and systems may encounter. This category has some CWEs that were previously associated with poor code quality. That was too general for us; in our opinion, this more specific category provides better guidance.
 
-Notable CWEs included in this category: *CWE-209 Generation of Error Message Containing Sensitive Information, CWE-234 Failure to Handle Missing Parameter, CWE-274 Improper Handling of Insufficient Privileges, CWE-476 NULL Pointer Dereference, *and *CWE-636 Not Failing Securely ('Failing Open'), *
+Notable CWEs included in this category: *CWE-209 Generation of Error Message Containing Sensitive Information, CWE-234 Failure to Handle Missing Parameter, CWE-274 Improper Handling of Insufficient Privileges, CWE-476 NULL Pointer Dereference,* and *CWE-636 Not Failing Securely ('Failing Open')*.
 
 
 ## Score table.


### PR DESCRIPTION
* Fix italic markers (they rendered as content)
* Fix sentence end; replace comma with full-stop

I used the GitHub file editor which seems to have lead to an end of file change as well. (Missing newline added?)