### PR TITLE
Fix typo in A02:2025 Security Misconfiguration section

### DIFF
--- a/2021/docs/en/2025/A02_2025-Security_Misconfiguration.md
+++ b/2021/docs/en/2025/A02_2025-Security_Misconfiguration.md
@@ -89,7 +89,7 @@ Secure installation processes should be implemented, including:
 * Sending security directives to clients, e.g., Security Headers.
 * An automated process to verify the effectiveness of the configurations and settings in all environments.
 * Proactively add a central configuration to intercept excessive error messages as a backup.
-* If these varifications are not automated, they should be manually verified annually at a minimum.
+* If these verifications are not automated, they should be manually verified annually at a minimum.
  
 
 ## Example attack scenarios. 


### PR DESCRIPTION
Replaced **"varifications"** with **"verifications"** in the "How to prevent" section for clarity and correctness. No other content changed.

fixes #831