### PR TITLE
Fix A08_2025 Example attack scenarios numbering inconsistency

### DIFF
--- a/2021/docs/en/2025/A08_2025-Software_or_Data_Integrity_Failures.md
+++ b/2021/docs/en/2025/A08_2025-Software_or_Data_Integrity_Failures.md
@@ -77,9 +77,9 @@ Software and data integrity failures relate to code and infrastructure that does
 
 **Scenario #2 Update without signing:** Many home routers, set-top boxes, device firmware, and others do not verify updates via signed firmware. Unsigned firmware is a growing target for attackers and is expected to only get worse. This is a major concern as many times there is no mechanism to remediate other than to fix in a future version and wait for previous versions to age out.
 
-Scenario #2 A developer has trouble finding the updated version of a package they are looking for, so they download it not from the regular, trusted package manager, but from a website online. The package is not signed, and thus there is no opportunity to ensure integrity. The package includes malicious code. 
+**Scenario #3 Use of Package from an Untrusted Source:** A developer has trouble finding the updated version of a package they are looking for, so they download it not from the regular, trusted package manager, but from a website online. The package is not signed, and thus there is no opportunity to ensure integrity. The package includes malicious code. 
 
-**Scenario #3 Insecure Deserialization:** A React application calls a set of Spring Boot microservices. Being functional programmers, they tried to ensure that their code is immutable. The solution they came up with is serializing the user state and passing it back and forth with each request. An attacker notices the "rO0" Java object signature (in base64) and uses the [Java Deserialization Scanner](https://github.com/federicodotta/Java-Deserialization-Scanner) to gain remote code execution on the application server.
+**Scenario #4 Insecure Deserialization:** A React application calls a set of Spring Boot microservices. Being functional programmers, they tried to ensure that their code is immutable. The solution they came up with is serializing the user state and passing it back and forth with each request. An attacker notices the "rO0" Java object signature (in base64) and uses the [Java Deserialization Scanner](https://github.com/federicodotta/Java-Deserialization-Scanner) to gain remote code execution on the application server.
 
 ## References.
 


### PR DESCRIPTION
The attack scenarios had #2 listed twice, and the second #2 didn't match the formatting of the rest of the list.

Updated to be correctly numbered from 1-4, include bold formatting, and have a brief title, to be consistent with the other entries.