### PR TITLE
PQC updates and more

### DIFF
--- a/2021/docs/en/2025/A04_2025-Cryptographic_Failures.md
+++ b/2021/docs/en/2025/A04_2025-Cryptographic_Failures.md
@@ -73,9 +73,8 @@ Beyond securing the transport layer, it is important to determine what data need
 * Is the received server certificate and the trust chain properly validated?
 * Are initialization vectors ignored, reused, or not generated sufficiently secure for the cryptographic mode of operation? Is an insecure mode of operation such as ECB in use? Is encryption used when authenticated encryption is more appropriate?
 * Are passwords being used as cryptographic keys in the absence of a password based key derivation function?
-* Is randomness used for cryptographic purposes that was not designed to meet cryptographic requirements? Even if the correct function is chosen, does it need to be seeded by the developer, and if not, has the developer over-written the strong seeding functionality built into it with a seed that lacks sufficient entropy/unpredictability?
+* Is randomness used that was not designed to meet cryptographic requirements? Even if the correct function is chosen, does it need to be seeded by the developer, and if not, has the developer over-written the strong seeding functionality built into it with a seed that lacks sufficient entropy/unpredictability?
 * Are deprecated hash functions such as MD5 or SHA1 in use, or are non-cryptographic hash functions used when cryptographic hash functions are needed?
-* Are deprecated cryptographic padding methods such as PKCS number 1 v1.5 in use?
 * Are cryptographic error messages or side channel information exploitable, for example in the form of padding oracle attacks?
 * Can the cryptographic algorithm be downgraded or bypassed?
 
@@ -94,10 +93,10 @@ Do the following, at a minimum, and consult the references:
 * Don't store sensitive data unnecessarily. Discard it as soon as possible or use PCI DSS compliant tokenization or even truncation. Data that is not retained cannot be stolen.
 * Make sure to encrypt all sensitive data at rest.
 * Ensure up-to-date and strong standard algorithms, protocols, and keys are in place; use proper key management.
-* Encrypt all data in transit with protocols TLS 1.2 and TLS 1.3 only, with forward secrecy (FS) ciphers, support quantum key change algorithms. Enforce encryption using HTTP Strict Transport Security (HSTS).
+* Encrypt all data in transit with protocols >= TLS 1.2 only, with forward secrecy (FS) ciphers, drop support for cipher block chaining (CBC) ciphers, support quantum key change algorithms. For HTTPS enforce encryption using HTTP Strict Transport Security (HSTS). Check everything with a tool.
 * Disable caching for responses that contain sensitive data. This includes caching in your CDN, web server, and any application caching (eg: Redis).
 * Apply required security controls as per the data classification.
-* Do not use unencrypted protocols such as FTP and avoid using SMTP for transmitting confidential data.
+* Do not use unencrypted protocols such as FTP, and STARTTLS. Avoid using SMTP for transmitting confidential data.
 * Store passwords using strong adaptive and salted hashing functions with a work factor (delay factor), such as Argon2, yescrypt, scrypt or PBKDF2-HMAC-SHA-512. For legacy systems using bcrypt, get more advice at [OWASP Cheat Sheet: Password Storage](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
 * Initialization vectors must be chosen appropriate for the mode of operation. This could mean using a CSPRNG (cryptographically secure pseudo random number generator). For modes that require a nonce, the initialization vector (IV) does not need a CSPRNG. In all cases, the IV should never be used twice for a fixed key.
 * Always use authenticated encryption instead of just encryption.


### PR DESCRIPTION
* emphasize PQC is important to tackle NOW
* modernize protocol section (TLS =<1.1 is obsolete now)
* SMTP needed to be rephrased as realistically it cannot be avoided other than throwing the old far^W dinosaur protocol away
* yescrypt is often used under Linux at least these days. 
* PBKDF2-HMAC-SHA-256 --> PBKDF2-HMAC-SHA-512 (sha2 is not state of the art anymore but may suffice the next couple of years for this type of PW encryption if there are enough rounds and have salts. But we should recommend the best as re-encryption often won't be done)
* remove 1st bcrypt instance so that it appears as legacy only

