### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/2017/OWASP-Top-10-2017-en.html
+++ b/2017/OWASP-Top-10-2017-en.html
@@ -59,7 +59,7 @@
 <p>&lt; replace me with a toc &gt;</p>
 <h1 id="o-about-owasp">O About OWASP</h1>
 <h2 id="about-owasp">About OWASP</h2>
-<p>The Open Web Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.</p>
+<p>The Open Worldwide Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.</p>
 <p>At OWASP, you'll find free and open:</p>
 <ul>
 <li>Application security tools and standards.</li>

--- a/2017/OWASP-Top-10-2017-fr.html
+++ b/2017/OWASP-Top-10-2017-fr.html
@@ -64,7 +64,7 @@
 <p>&lt; replace me with a toc &gt;</p>
 <h1>O A propos de l'OWASP</h1>
 <h2>A propos de l'OWASP</h2>
-<p>The Open Web Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.</p>
+<p>The Open Worldwide Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.</p>
 <p>At OWASP, you'll find free and open:</p>
 <ul>
 <li>Application security tools and standards.</li>

--- a/2017/OWASP-Top-10-2017-pt-br.html
+++ b/2017/OWASP-Top-10-2017-pt-br.html
@@ -54,7 +54,7 @@ document.write('<a h'+'ref'+'="ma'+'ilto'+':'+e+'">'+e+'<\/'+'a'+'>');
 <p>&lt; replace me with a toc &gt;</p>
 <h1 id="o-sobre-a-owasp">O Sobre a OWASP</h1>
 <h2 id="sobre-a-owasp">Sobre a OWASP</h2>
-<p>The Open Web Application Security Project (OWASP) é uma comunidade aberta, dedicada a capacitar as organizações a desenvolver, adquirir e manter aplicações e APIs confiáveis.</p>
+<p>The Open Worldwide Application Security Project (OWASP) é uma comunidade aberta, dedicada a capacitar as organizações a desenvolver, adquirir e manter aplicações e APIs confiáveis.</p>
 <p>Na OWASP se pode encontrar, grátis e de forma aberta...</p>
 <ul>
 <li>Normas e ferramentas de segurança em aplicações<br /></li>

--- a/2017/en/0x01-about-owasp.md
+++ b/2017/en/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## About OWASP
 
-The Open Web Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.
+The Open Worldwide Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.
 
 At OWASP, you'll find free and open:
 

--- a/2017/fr/0x01-about-owasp.md
+++ b/2017/fr/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## A propos de l'OWASP
 
-L'Open Web Application Security Project (OWASP) est une communauté dont la tâche est de permettre aux organisations de développer, acheter et maintenir des applications et des APIs dignes de confiance. 
+L'Open Worldwide Application Security Project (OWASP) est une communauté dont la tâche est de permettre aux organisations de développer, acheter et maintenir des applications et des APIs dignes de confiance. 
 
 Avec l'OWASP, vous trouverez de façon gratuite et libre :
 

--- a/2017/he/0x01-about-owasp.md
+++ b/2017/he/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## About OWASP
 
-The Open Web Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.
+The Open Worldwide Application Security Project (OWASP) is an open community dedicated to enabling organizations to develop, purchase, and maintain applications and APIs that can be trusted.
 
 At OWASP, you'll find free and open:
 

--- a/2017/id/0x01-about-owasp.md
+++ b/2017/id/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## tentang OWASP
 
-Open Web Application Security Project (OWASP) adalah komunitas terbuka yang didedikasikan untuk memungkinkan organisasi mengembangkan, membeli, dan memelihara aplikasi dan API yang dapat dipercaya.
+Open Worldwide Application Security Project (OWASP) adalah komunitas terbuka yang didedikasikan untuk memungkinkan organisasi mengembangkan, membeli, dan memelihara aplikasi dan API yang dapat dipercaya.
 
 Di OWASP anda akan menemukan secara bebas dan terbuka mengenai:
 

--- a/2017/ja/0x01-about-owasp.md
+++ b/2017/ja/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## OWASPについて
 
-The Open Web Application Security Project (OWASP/日本語: オワスプ) は、オープンなコミュニティであり、組織がアプリケーションやAPIを開発、調達、メンテナンスするにあたりそれらが信頼できるようになることに専念しています。
+The Open Worldwide Application Security Project (OWASP/日本語: オワスプ) は、オープンなコミュニティであり、組織がアプリケーションやAPIを開発、調達、メンテナンスするにあたりそれらが信頼できるようになることに専念しています。
 
 OWASPには、自由でオープンなものがあります:
 

--- a/2017/ja/OWASP-Top-10-2017-ja.html
+++ b/2017/ja/OWASP-Top-10-2017-ja.html
@@ -59,7 +59,7 @@
 <p>&lt; replace me with a toc &gt;</p>
 <h1 id="o-owasp">O OWASPについて</h1>
 <h2 id="owasp">OWASPについて</h2>
-<p>The Open Web Application Security Project (OWASP/日本語: オワスプ) は、オープンなコミュニティであり、組織がアプリケーションやAPIを開発、調達、メンテナンスするにあたりそれらが信頼できるようになることに専念しています。</p>
+<p>The Open Worldwide Application Security Project (OWASP/日本語: オワスプ) は、オープンなコミュニティであり、組織がアプリケーションやAPIを開発、調達、メンテナンスするにあたりそれらが信頼できるようになることに専念しています。</p>
 <p>OWASPには、自由でオープンなものがあります:</p>
 <ul>
 <li>アプリケーションセキュリティのためのツールと標準</li>

--- a/2017/pt-br/0x01-about-owasp.md
+++ b/2017/pt-br/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## Sobre a OWASP
 
-*Open Web Application Security Project* (OWASP) é uma comunidade aberta, dedicada a capacitar as organizações a desenvolver, adquirir e manter aplicações e APIs confiáveis. 
+*Open Worldwide Application Security Project* (OWASP) é uma comunidade aberta, dedicada a capacitar as organizações a desenvolver, adquirir e manter aplicações e APIs confiáveis. 
 
 Em OWASP se pode encontrar, grátis e de forma aberta...
 

--- a/2017/pt-pt/0x01-about-owasp.md
+++ b/2017/pt-pt/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## Sobre a OWASP
 
-OWASP - Open Web Application Security Project é uma comunidade aberta dedicada
+OWASP - Open Worldwide Application Security Project é uma comunidade aberta dedicada
 a permitir que as organizações desenvolvam, adquiram e mantenham aplicações e
 APIs confiáveis.
 

--- a/2017/ro/0x01-about-owasp.md
+++ b/2017/ro/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## Despre OWASP
 
-Proiectul Open Web Application Security Project (OWASP) este o comunitate deschisă dedicată pentru a permite organizațiilor să dezvolte, să cumpere și să întrețină aplicații și API-uri care pot fi de încredere.
+Proiectul Open Worldwide Application Security Project (OWASP) este o comunitate deschisă dedicată pentru a permite organizațiilor să dezvolte, să cumpere și să întrețină aplicații și API-uri care pot fi de încredere.
 
 La OWASP, veți găsi gratuit și liber:
 

--- a/2017/tr/0x01-about-owasp.md
+++ b/2017/tr/0x01-about-owasp.md
@@ -2,7 +2,7 @@
 
 ## OWASP Hakkında
 
-Open Web Application Security Project (OWASP), kendisini kurumların güvenilebilir uygulamalar ve API’ler geliştirmesini, satın almasını ve sürdürmesini sağlamaya adamış açık bir topluluktur. 
+Open Worldwide Application Security Project (OWASP), kendisini kurumların güvenilebilir uygulamalar ve API’ler geliştirmesini, satın almasını ve sürdürmesini sağlamaya adamış açık bir topluluktur. 
 
 OWASP ile, aşağıdakileri açık ve ücretsiz bir şekilde temin edebilirsiniz:
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)
- BlueSky: [arkid15r.com](https://bsky.app/profile/arkid15r.com)