### PR TITLE
Authentication failures: Respect intended use of credentials

### DIFF
--- a/2025/docs/en/A07_2025-Authentication_Failures.md
+++ b/2025/docs/en/A07_2025-Authentication_Failures.md
@@ -82,6 +82,7 @@ When an attacker is able to trick a system into recognizing an invalid or incorr
 
 * Does not correctly invalidate user sessions or authentication tokens (mainly single sign-on (SSO) tokens) during logout or a period of inactivity.
 
+* Does not correctly assert the scope and intended audience of the provided credentials.
 
 ## How to prevent. 
 
@@ -106,6 +107,8 @@ When an attacker is able to trick a system into recognizing an invalid or incorr
 * Use a server-side, secure, built-in session manager that generates a new random session ID with high entropy after login. Session identifiers should not be in the URL, be securely stored in a secure cookie, and invalidated after logout, idle, and absolute timeouts. 
 
 * Ideally, use a premade, well-trusted system to handle authentication, identity, and session management. Transfer this risk whenever possible by buying and utilizing a hardened and well tested system.
+
+* Verify the intended use of provided credentials, e.g. for JWTs validate `aud`, `iss` claims and scopes
 
 
 ## Example attack scenarios. 


### PR DESCRIPTION
For stateless authentication (e.g. JWTs) one has to validate the intended usage of a credential