### PR TITLE
Fix formatting and clarify scenarios in documentation #837

### DIFF
--- a/2025/docs/en/A10_2025-Mishandling_of_Exceptional_Conditions.md
+++ b/2025/docs/en/A10_2025-Mishandling_of_Exceptional_Conditions.md
@@ -94,11 +94,10 @@ If possible, your entire organization should handle exceptional conditions in th
 
 ## Example attack scenarios. 
 
-**FIXME**: Update examples to be more modern
-
 **Scenario #1:** Resource exhaustion via mishandling of exceptional conditions (Denial of Service) could be caused if the application catches exceptions when files are uploaded, but doesn’t properly release resources after. Each new exception leaves resources locked or otherwise unavailable, until all resources are used up.
 
-**Scenario #2:** Sensitive data exposure via improper handling or database errors that reveals the full system error to the user. The attacker continues to force errors in order to use the sensitive system information to create a better SQL injection attack. The sensitive data in the user error messages are reconnaissance. 
+**Scenario #2:** Sensitive data exposure via improper handling or database errors that reveals the full system error to the user. The attacker continues to force errors in order to use the sensitive system information to create a better SQL injection attack. The sensitive data in the user error messages are reconnaissance.
+
 **Scenario #3:** State corruption in financial transactions could be caused by an attacker interrupting a multi-step transaction via network disruptions. Imagine the transaction order was: debit user account, credit destination account, log transaction. If the system doesn’t properly roll back the entire transaction (fail closed) when there is an error part way through, the attacker could potentially drain the user’s account, or possibly a race condition that allows the attacker to send money to the destination multiple times.
 
 


### PR DESCRIPTION
and deleted 'FIXME: Update examples to be more modern'