### PR TITLE
Fix 2025 sitewide layout breakage caused by RC watermark

### DIFF
--- a/2025/docs/assets/css/RC-stylesheet.css
+++ b/2025/docs/assets/css/RC-stylesheet.css
@@ -1,11 +1,41 @@
-/* Styles written here are applied to all URLs have `/2025/` in them */
-article.md-content__inner.md-typeset:before {
-    content: "RELEASE CANDIDATE";
-    -webkit-transform: rotate(331deg);
-    -moz-transform: rotate(331deg);
-    -o-transform: rotate(331deg);
-    transform: rotate(331deg);
-    font-size: 10em;
-    color: rgba(255, 5, 5, 0.17);
-    position: absolute;
+body {
+  position: relative;
+}
+
+body::before {
+  content: "RELEASE\A CANDIDATE";
+  white-space: pre-line;
+
+  position: absolute;
+  top: calc(var(--md-header-height, 3.5rem) + 3.65rem);
+  left: 50%;
+  transform: translateX(-50%) rotate(331deg);
+  transform-origin: center;
+
+  font-size: clamp(5em, 10vw, 15em);
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  line-height: 1.50;
+
+  color: rgba(255, 5, 5, 0.17);
+  pointer-events: none;
+  user-select: none;
+  z-index: 2;
+}
+
+@media screen and (min-width: 960px) {
+  body::before {
+    font-weight: 400;
+    top: calc(var(--md-header-height, 3.5rem) + 4.9rem);
+    left: 64%;
+    letter-spacing: .05em;
+
+  }
+}
+
+@media print {
+  body::before {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
This fix closes issue #877 by updating the RC watermark CSS to be mobile responsive and prevent broken page layouts caused by its current overflow behaviors. As detailed in the issue opened, the layout breakage affects virtually every page and is first apparent at around breakpoint 1450px and increases in severity as the screen size grows smaller. The issue creates whitespace gaps on the right side of the header and footer and on mobile screen sizes the whitespace created can even exceed the width of the page content itself. This is both a visual defect and a usability/accessibility concern, as unintended horizontal overflow can trap focus off-screen, complicate keyboard navigation, and create confusing touch scrolling behavior.

The fix retains the same essential design intent as it places the watermark in roughly the same position on each page with the same scale on desktop and proportionally appropriate ones for tablet and mobile screen sizes.

## Testing

A live demo is available to test at [top10.ritovision.com](https://top10.ritovision.com/) or you can test the fix on a local build.

The fix should be straight forward to verify. Visit any page at any screen size below 1450px on any browser or device and the page should look normal; you shouldn't see right side page overflow creating noticeable whitespace breaking the header and footer. If there are overflow issues on certain pages, it's likely caused by other unrelated issues to this fix; the homepage and other pages linked in the main menu I have confirmed as fixed and stable.

I have tested the fix on Chrome, Firefox and Edge on desktop and mobile browsers and found it stable. You're welcome to verify and also check on Safari if warranted.

## Before and After Screenshots
These screenshots are based on Chrome desktop and mobile browsers at different breakpoints.

### 1300

**Before** 
<img width="1301" height="797" alt="Before image on desktop showing broken page margin" src="https://github.com/user-attachments/assets/1842c8e2-6bdf-406c-87f9-feec06fa83a3" />
<br><br>

**After**
<img width="1301" height="797" alt="After image on desktop showing fixed page layout" src="https://github.com/user-attachments/assets/38be9fde-8cdc-44f6-96a4-b06d0b482734" />

### 1000

**Before Header** 
<img width="997" height="859" alt="Before image showing header broken" src="https://github.com/user-attachments/assets/e35e3271-6059-475f-a1ff-bbea4bb67c1f" />
<br><br>

**After Header**
<img width="999" height="797" alt="After image showing page fixed and header normal" src="https://github.com/user-attachments/assets/d34e2d05-0f6c-4b64-bb05-d86724a8dd75" />
<br><br>

**Before Footer**
<img width="997" height="859" alt="Before image showing page layout broken with footer having extra whitespace" src="https://github.com/user-attachments/assets/2bbfbcfc-6588-441c-be27-f7e545ea66ed" />
<br><br>

**After Footer**
<img width="999" height="797" alt="After image showing page fixed and footer normal" src="https://github.com/user-attachments/assets/783044b9-5478-4209-bb26-1b04eecb5edc" />


### 600

**Before** 
<img width="601" height="694" alt="Before image showing page layout broken" src="https://github.com/user-attachments/assets/7cf0b1e0-9adb-44ce-bbf2-aabd3555a809" />
<br><br>

**After**
<img width="599" height="800" alt="After image showing page layout fixed" src="https://github.com/user-attachments/assets/2bc18524-67ce-44a0-92ba-6928be69c59c" />

### Around 450

**Before (Zoomed out, which you should not be able to do on mobile)** 
<img width="540" height="1070" alt="Before image showing mobile layout broken" src="https://github.com/user-attachments/assets/d8440c73-2d1d-4225-8cff-b294d66db8f8" />
<br><br>

**After**
<img width="540" height="1070" alt="After image showing mobile layout normal" src="https://github.com/user-attachments/assets/c7219161-e871-44da-8bcf-b2e908b1dabe" />


