### PR TITLE
Fix 2021 site-wide broken mobile layouts from header overflow

### DIFF
--- a/2021/docs/assets/css/overrides.css
+++ b/2021/docs/assets/css/overrides.css
@@ -1,0 +1,29 @@
+/* Prevent header layout overflow that breaks right page margin */
+@media screen and (max-width: 959.99px) {
+
+  /* Contain header layout within the viewport */
+  .md-header,
+  .md-header__inner,
+  nav.md-header__inner.md-grid {
+    max-width: 100% !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    overflow-x: clip !important;
+  }
+
+  /* Allow header children to shrink below their content width when needed */
+  nav.md-header__inner.md-grid>* {
+    min-width: 0 !important;
+  }
+
+  /* Truncate long header title text to avoid widening the page */
+  .md-header__title,
+  .md-header__title .md-header__topic,
+  .md-header__title .md-header__ellipsis {
+    min-width: 0 !important;
+    max-width: 100% !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+  }
+}

--- a/2021/mkdocs.yml
+++ b/2021/mkdocs.yml
@@ -5,6 +5,8 @@ repo_name: OWASP/Top10
 repo_url: https://github.com/OWASP/Top10
 copyright: © Copyright 2021-2025 - OWASP Top 10 Team - This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.
 docs_dir: docs
+extra_css:
+  - assets/css/overrides.css
 theme:
   name: material
   language: en


### PR DESCRIPTION
## Summary
This PR for the 2021 site fixes site-wide broken mobile layouts caused by horizontal overflow from the header title container `.md-header__title--active`. The fix restores normal page behavior for all pages within the affected viewport widths ≤ 959px by preventing:
1. horizontal page scroll
2. the header from being hidden when scrolling
3. excess whitespace along the right side of the header and footer
4. unintended zoom out and panning behaviors on mobile devices

It adds `override.css` for a targeted fix and imports it from `mkdocs.yml` (required to apply the CSS file to the theme).

Closes #884

## Testing

 You can test the fix at this live demo site [top10-21.ritovision.com](https://top10-21.ritovision.com/) or on a local build.


To verify:
- Navigate to any page (Home and About are good examples) on a **mobile device (under 960px width)**
- Confirm there is **no horizontal overflow** and no excess whitespace around the sides of the header and footer
- Scroll down and confirm the **header remains visible** (fixed) and does not disappear
 
 I have tested and confirmed the fix is stable across Chrome, Firefox, Edge, Opera mobile and desktop browsers.

***Note:** In testing a comparison of the updated fix and the current site build, you should test with a mobile browser on a mobile device since desktop browsers have shown inconsistent reproduction of the issue compared to on mobile.*

## Before and After Screenshots

The issue manifests the same across all pages on the site, so the Home and About pages were chosen here as a representative demonstration of all other pages being fixed. Screenshots from Chrome mobile browser at around 450px screen size.

**Top of Homepage - BEFORE**
*Notice the excess whitespace along the right side of the header*

<img width="360" height="713" alt="Homepage zoomed out with whitespace along the header" src="https://github.com/user-attachments/assets/046de43d-3c6f-4fa3-9986-0a9e2d3d3d01" />
<br />
<br />

**Bottom of Homepage - BEFORE**
*Notice the fixed header is missing and there is excess whitespace along the right side of the footer*

<img width="360" height="713" alt="Bottom of homepage with missing header and broken footer" src="https://github.com/user-attachments/assets/749dd1df-a695-42e6-b81d-c1ee6a474028" />
<br />
<br />

**Bottom of Homepage - AFTER**
*Notice the header is still visible while at the bottom of the page, and both the header and footer take up the full page width without any excess whitespace on the right side.*

<img width="360" height="713" alt="bottom of the homepage with page behaving normally" src="https://github.com/user-attachments/assets/422ac549-f933-4d6c-871a-e39830e28583" />
<br />
<br />

**About page - BEFORE**
*Notice the same excess whitespace to the right of the header as on the homepage*

<img width="360" height="713" alt="About page zoomed out" src="https://github.com/user-attachments/assets/74423a78-8640-4eeb-ae8c-6f251b5e7462" />
<br />
<br />

**About page - AFTER**
*Notice there is no more excess whitespace to the right of the header*

<img width="360" height="713" alt="about AFTER screenshot" src="https://github.com/user-attachments/assets/439e7b1d-54b7-4e33-8a35-c4c5e0792f1a" />


