### PR TITLE
 Fix markdown syntax issues and minor typos in OWASP Top 10 (2025)

### DIFF
--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../assets/css/RC-stylesheet.css" />
+
 # What are Application Security Risks?
 Attackers can potentially use many different paths through your application to do harm to your business or organization. Each of these ways poses a potential risk that needs to be investigated.
 
@@ -9,46 +11,34 @@ Attackers can potentially use many different paths through your application to d
     <strong>Threat Agents</strong>
    </td>
    <td>
-    <strong>Attack \
-Vectors</strong>
+  <strong>Attack Vectors</strong>
    </td>
    <td>
     <strong>Exploitability</strong>
    </td>
    <td>
-    <strong>Likelihood of Missing Security</strong>
-<p style="text-align: center">
-
-    <strong>Controls</strong>
+   <strong>Likelihood of Missing Security Controls</strong>
    </td>
    <td>
-    <strong>Technical</strong>
-<p style="text-align: center">
-
-    <strong>Impacts</strong>
+  <strong>Technical Impacts</strong>
    </td>
    <td>
-    <strong>Business</strong>
-<p style="text-align: center">
-
-    <strong>Impacts</strong>
+  <strong>Business Impacts</strong>
    </td>
   </tr>
   <tr>
    <td>
-    <strong>By environment, \
-dynamic by situation picture</strong>
+  <strong>By environment, dynamic by situation picture</strong>
+
    </td>
    <td>
-    <strong>By Application  exposure (by environment</strong>
+   <strong>By Application exposure (by environment)</strong>
    </td>
    <td>
     <strong>Avg Weighted Exploit</strong>
    </td>
    <td>
-    <strong>Missing Controls \
-by average Incidence rate \
-Weighed by coverage</strong>
+  <strong>Missing Controls by average incidence rate weighted by coverage</strong>
    </td>
    <td>
     <strong>Avg Weighted Impact</strong>
@@ -60,7 +50,8 @@ Weighed by coverage</strong>
 </table>
 
 
-In our Risk Rating we have taken into account the universal parameters of exploitability, average likelihood of missing security controls for a weakness and its technical impacts. 
+In our Risk Rating, we have taken into account the universal parameters of exploitability
+, average likelihood of missing security controls for a weakness and its technical impacts. 
 
 Each organization is unique, and so are the threat actors for that organization, their goals, and the impact of any breach. If a public interest organization uses a content management system (CMS) for public information and a health system uses that same exact CMS for sensitive health records, the threat actors and business impacts can be very different for the same software. It is critical to understand the risk to your organization based on the exposure of the application, the applicable threat agents by situation picture (for targeted and undirected attacks by business and location) and the individual business impacts. 
 

--- a/2025/docs/en/A06_2025-Insecure_Design.md
+++ b/2025/docs/en/A06_2025-Insecure_Design.md
@@ -89,7 +89,7 @@ Often self-responsibility of developers is underappreciated. Foster a culture of
 * Establish and use a secure development lifecycle with AppSec professionals to help evaluate and design security and privacy-related controls
 * Establish and use a library of secure design patterns or paved-road components
 * Use threat modeling for critical parts of the application such as authentication, access control, business logic, and key flows
-* User threat modeling as an educational tool to generate a security mindset
+*  Use threat modeling as an educational tool to generate a security mindset
 * Integrate security language and controls into user stories
 * Integrate plausibility checks at each tier of your application (from frontend to backend)
 * Write unit and integration tests to validate that all critical flows are resistant to the threat model. Compile use-cases *and* misuse-cases for each tier of your application.


### PR DESCRIPTION
### Summary
This pull request fixes several minor documentation issues in the OWASP Top 10
(2025) draft to improve readability and correctness.

### Changes Made
- Fixed a missing closing bracket in the “By Application exposure (by environment)” section
- Removed an unnecessary extra space in the DSOM (DevSecOps Maturity Model) reference
- Corrected a markdown syntax error in the OWASP ASVS reference
- Fixed a typo in the “User threat modeling as an educational” sentence

### Files Affected
- `2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md`
- `2025/docs/en/0x03_2025-Establishing_a_Modern_Application_Security_Program.md`
- `2025/docs/en/A06_2025-Insecure_Design.md`

### Scope
- Documentation-only changes
- No changes to technical meaning or OWASP risk definitions

### Checklist
- Markdown syntax validated
- Changes are minimal and focused
- No functional or semantic changes

Thank you for reviewing this contribution.
