### PR TITLE
Fixed typo in A01 section of 2025 version

### DIFF
--- a/2025/docs/en/A01_2025-Broken_Access_Control.md
+++ b/2025/docs/en/A01_2025-Broken_Access_Control.md
@@ -65,7 +65,7 @@ Access control enforces policy such that users cannot act outside of their inten
 * Bypassing access control checks by modifying the URL (parameter tampering or force browsing), internal application state, or the HTML page, or by using an attack tool that modifies API requests.
 * Permitting viewing or editing someone else's account by providing its unique identifier (insecure direct object references)
 * An accessible API with missing access controls for POST, PUT, and DELETE.
-* Elevation of privilege. Acting as a user without being logged in or or gaining privileges beyond those expected of the logged in user (e.g. admin access).
+* Elevation of privilege. Acting as a user without being logged in or gaining privileges beyond those expected of the logged in user (e.g. admin access).
 * Metadata manipulation, such as replaying or tampering with a JSON Web Token (JWT) access control token, a cookie or hidden field manipulated to elevate privileges, or abusing JWT invalidation.
 * CORS misconfiguration allows API access from unauthorized or untrusted origins.
 * Force browsing (guessing URLs) to authenticated pages as an unauthenticated user or to privileged pages as a standard user.


### PR DESCRIPTION
Removed extra "or" in the sentence describing privilege escalation.