### PR TITLE
Fix incorrect CWE mapping for Use of Obsolete Function in A03

### DIFF
--- a/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
+++ b/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
@@ -161,7 +161,7 @@ Every organization must ensure an ongoing plan for monitoring, triaging, and app
 
 ## List of Mapped CWEs
 
-* [CWE-447 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/447.html)
+* [CWE-477 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/477.html)
 
 * [CWE-1035 2017 Top 10 A9: Using Components with Known Vulnerabilities](https://cwe.mitre.org/data/definitions/1035.html)
 


### PR DESCRIPTION
Corrected an incorrect CWE reference in A03:2025 Software Supply Chain Failures.

The "Use of Obsolete Function" entry was incorrectly mapped to CWE-447
(Unimplemented or Unsupported Feature in UI). This PR updates the mapping
to CWE-477 and fixes the associated MITRE link, aligning it with the
Background section and official CWE definitions.
