### PR TITLE
Fix typo: Change CWE-447 to CWE-477 in A03

### DIFF
--- a/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
+++ b/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
@@ -161,7 +161,7 @@ Every organization must ensure an ongoing plan for monitoring, triaging, and app
 
 ## List of Mapped CWEs
 
-* [CWE-447 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/447.html)
+* [CWE-477 Use of Obsolete Function](https://cwe.mitre.org/data/definitions/477.html)
 
 * [CWE-1035 2017 Top 10 A9: Using Components with Known Vulnerabilities](https://cwe.mitre.org/data/definitions/1035.html)
 


### PR DESCRIPTION
CWE-447 refers to 'Unimplemented Feature', while 'Use of Obsolete Function' is CWE-477. This fixes the typo.