### PR TITLE
Reorder A04 "how to prevent" paragraph for clarity

### DIFF
--- a/2025/docs/en/A04_2025-Cryptographic_Failures.md
+++ b/2025/docs/en/A04_2025-Cryptographic_Failures.md
@@ -58,7 +58,7 @@ Moving down two positions to #4, this weakness focuses on failures related to th
 
 ## Description. 
 
-Generally speaking, all data in transit should be fully encrypted at the [application layer](https://en.wikipedia.org/wiki/Application_layer) ([OSI layer](https://en.wikipedia.org/wiki/OSI_model) 7). Certificate management for publicly exposed services is being simplified by services like [LetsEncrypt.org](https://LetsEncrypt.org). Major cloud vendors provide even more tightly integrated certificate management services for their specific platforms. 
+Generally speaking, all data in transit should be fully encrypted in transit using TLS. Certificate management for publicly exposed endpoints is being simplified by services like [LetsEncrypt.org](https://LetsEncrypt.org). Major cloud vendors provide tightly integrated certificate management services for their specific platforms. 
 
 Beyond securing the transport layer, it is important to determine what data needs encryption at rest as well as what data needs extra encryption in transit (at the [application layer](https://en.wikipedia.org/wiki/Application_layer), OSI layer 7). For example, passwords, credit card numbers, health records, personal information, and business secrets require extra protection, especially if that data falls under privacy laws, e.g., EU's General Data Protection Regulation (GDPR), or regulations such as PCI Data Security Standard (PCI DSS). For all such data:
 


### PR DESCRIPTION
* Also advice to deprecate RSA ciphers as browsers don´t necessarily need them anymore.

Note (and related) the Bleichenbacher issue (PKCS \#1 1.5) should be removed at least as browser/server crypto is concerned. It's 8 years old, see https://robotattack.org/ . Don't know however whether this could be still an issue for developers (libraries). Anyone?


