### PR TITLE
fix: correct CWE-201 official name in A01 mapped CWEs list

### DIFF
--- a/2025/docs/en/A01_2025-Broken_Access_Control.md
+++ b/2025/docs/en/A01_2025-Broken_Access_Control.md
@@ -157,7 +157,7 @@ from the command line.
 
 * [CWE-200 Exposure of Sensitive Information to an Unauthorized Actor](https://cwe.mitre.org/data/definitions/200.html)
 
-* [CWE-201 Exposure of Sensitive Information Through Sent Data](https://cwe.mitre.org/data/definitions/201.html)
+* [CWE-201 Insertion of Sensitive Information Into Sent Data](https://cwe.mitre.org/data/definitions/201.html)
 
 * [CWE-219 Storage of File with Sensitive Data Under Web Root](https://cwe.mitre.org/data/definitions/219.html)
 


### PR DESCRIPTION
### Related Issue:
Related to #930

### What was wrong?
CWE-201 was listed under the **List of Mapped CWEs** in A01:2025 with an incorrect name:
> *"Exposure of Sensitive Information Through Sent Data"*

### What was changed?
Updated the CWE-201 name to match the official CWE dictionary:
> *"Insertion of Sensitive Information Into Sent Data"*

Reference: https://cwe.mitre.org/data/definitions/201.html