### PR TITLE
fix: correct official names for multiple CWEs in mapped lists

### DIFF
--- a/2025/docs/en/A01_2025-Broken_Access_Control.md
+++ b/2025/docs/en/A01_2025-Broken_Access_Control.md
@@ -157,7 +157,7 @@ from the command line.
 
 * [CWE-200 Exposure of Sensitive Information to an Unauthorized Actor](https://cwe.mitre.org/data/definitions/200.html)
 
-* [CWE-201 Insertion of Sensitive Information Into Sent Data](https://cwe.mitre.org/data/definitions/201.html)
+* [CWE-201 Exposure of Sensitive Information Through Sent Data](https://cwe.mitre.org/data/definitions/201.html)
 
 * [CWE-219 Storage of File with Sensitive Data Under Web Root](https://cwe.mitre.org/data/definitions/219.html)
 

--- a/2025/docs/en/A01_2025-Broken_Access_Control.md
+++ b/2025/docs/en/A01_2025-Broken_Access_Control.md
@@ -157,7 +157,7 @@ from the command line.
 
 * [CWE-200 Exposure of Sensitive Information to an Unauthorized Actor](https://cwe.mitre.org/data/definitions/200.html)
 
-* [CWE-201 Exposure of Sensitive Information Through Sent Data](https://cwe.mitre.org/data/definitions/201.html)
+* [CWE-201 Insertion of Sensitive Information Into Sent Data](https://cwe.mitre.org/data/definitions/201.html)
 
 * [CWE-219 Storage of File with Sensitive Data Under Web Root](https://cwe.mitre.org/data/definitions/219.html)
 

--- a/2025/docs/en/A07_2025-Authentication_Failures.md
+++ b/2025/docs/en/A07_2025-Authentication_Failures.md
@@ -148,9 +148,9 @@ When an attacker is able to trick a system into recognizing an invalid or incorr
 
 * [CWE-297 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/297.html)
 
-* [CWE-298 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/298.html)
+* [CWE-298 Improper Validation of Certificate Expiration](https://cwe.mitre.org/data/definitions/298.html)
 
-* [CWE-299 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/299.html)
+* [CWE-299 Improper Check for Certificate Revocation](https://cwe.mitre.org/data/definitions/299.html)
 
 * [CWE-300 Channel Accessible by Non-Endpoint](https://cwe.mitre.org/data/definitions/300.html)
 

--- a/2025/docs/en/A09_2025-Security_Logging_and_Alerting_Failures.md
+++ b/2025/docs/en/A09_2025-Security_Logging_and_Alerting_Failures.md
@@ -127,7 +127,7 @@ There are commercial and open-source application protection products such as the
 
 * [CWE-117 Improper Output Neutralization for Logs](https://cwe.mitre.org/data/definitions/117.html)
 
-* [CWE-221 Information Loss of Omission](https://cwe.mitre.org/data/definitions/221.html)
+* [CWE-221 Information Loss or Omission](https://cwe.mitre.org/data/definitions/221.html)
 
 * [CWE-223 Omission of Security-relevant Information](https://cwe.mitre.org/data/definitions/223.html)
 


### PR DESCRIPTION
### Related Issue:
Related to #936 

### What was wrong?
Several CWEs were listed under the **List of Mapped CWEs** sections with outdated or incorrect names that did not match the official CWE dictionary

### What was changed?

Updated the following entries to match the official CWE dictionary:

| CWE ID | Previous Name | Correct Official Name |
| --- | --- | --- |
| **CWE-221** | Information Loss of Omission | Information Loss or Omission |
| **CWE-298** | Improper Validation of Certificate with Host Mismatch | Improper Validation of Certificate Expiration |
| **CWE-299** | Improper Validation of Certificate with Host Mismatch | Improper Check for Certificate Revocation |
