### PR TITLE
feature (theme): add light/dark mode toggle across all mkdocs configs

### DIFF
--- a/2021/mkdocs.yml
+++ b/2021/mkdocs.yml
@@ -13,6 +13,15 @@ theme:
     - navigation.sections
     - navigation.instant
     - search.suggest
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 nav:
   - Welcome Page: index.md

--- a/2021/mkdocs.yml
+++ b/2021/mkdocs.yml
@@ -14,11 +14,14 @@ theme:
     - navigation.instant
     - search.suggest
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/brightness-4
         name: Switch to light mode

--- a/2025/mkdocs.yml
+++ b/2025/mkdocs.yml
@@ -13,6 +13,15 @@ theme:
     - navigation.sections
     - navigation.instant
     - search.suggest
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 nav:
   - Home: 'en/index.md'

--- a/2025/mkdocs.yml
+++ b/2025/mkdocs.yml
@@ -14,11 +14,14 @@ theme:
     - navigation.instant
     - search.suggest
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/brightness-4
         name: Switch to light mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,18 @@ plugins:
 #For material
 theme:
   name: material
-  custom_dir: custom_theme/
+  # custom_dir: custom_theme/
   favicon: assets/WebSite_Favicon.png
   logo: "assets/OWASP_Logo_Transp.png"
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences # Required by Pygments

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,11 +41,14 @@ theme:
   favicon: assets/WebSite_Favicon.png
   logo: "assets/OWASP_Logo_Transp.png"
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
## Summary
Adds a light/dark mode toggle to the OWASP Top 10 documentation site by configuring the `palette` option in the MkDocs Material theme.

## Changes
Added a `palette` block to:
- mkdocs.yml
- 2021/mkdocs.yml
- 2025/mkdocs.yml

Two schemes:
- `default`: light mode with a `☀️` toggle to switch to dark
- `slate`: dark mode with a `🌙` toggle to switch to light

No dependencies added.

## Reason
The OWASP Top 10 site currently has no dark mode. The MkDocs Material theme
supports this natively with a simple config change which has been applied.

## Testing
Tested locally:
- `2021/:` `python -m mkdocs serve` from `2021/` directory, all language builds passed
- `2025/:` `python -m mkdocs serve` from `2025/` directory, English build passed
- Zero new errors introduced
