### PR TITLE
Fix typo in A03:2025 incidence rate (issue #898)

### DIFF
--- a/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
+++ b/2025/docs/en/A03_2025-Software_Supply_Chain_Failures.md
@@ -3,7 +3,7 @@
 
 ## Background.
 
-This was top-ranked in the Top 10 community survey with exactly 50% respondents ranking it #1. Since initially appearing in the 2013 Top 10 as "A9 – Using Components with Known Vulnerabilities", the risk has grown in scope to include all supply chain failures, not just ones involving known vulnerabilities. Despite this increased scope, supply chain failures continue to be a challenge to identify with only 11 Common Vulnerability and Exposures (CVEs) having the related CWEs. However, when tested and reported in the contributed data, this category has the highest average incidence rate at 5.19%. The relevant CWEs are *CWE-477: Use of Obsolete Function, CWE-1104: Use of Unmaintained Third Party Components*, CWE-1329: *Reliance on Component That is Not Updateable*, and *CWE-1395: Dependency on Vulnerable Third-Party Component*.
+This was top-ranked in the Top 10 community survey with exactly 50% respondents ranking it #1. Since initially appearing in the 2013 Top 10 as "A9 – Using Components with Known Vulnerabilities", the risk has grown in scope to include all supply chain failures, not just ones involving known vulnerabilities. Despite this increased scope, supply chain failures continue to be a challenge to identify with only 11 Common Vulnerability and Exposures (CVEs) having the related CWEs. However, when tested and reported in the contributed data, this category has the highest average incidence rate at 5.72%. The relevant CWEs are *CWE-477: Use of Obsolete Function, CWE-1104: Use of Unmaintained Third Party Components*, CWE-1329: *Reliance on Component That is Not Updateable*, and *CWE-1395: Dependency on Vulnerable Third-Party Component*.
 
 
 ## Score table.


### PR DESCRIPTION
highest average incidence rate in A03:2025 section

This PR fixes an inconsistency in the A03:2025 section.

The average incidence rate in the descriptive text (5.19%) did not match the value in the score table (5.72%). Updated the text to 5.72% for consistency.

Fixes #898