### PR TITLE
Add SECURITY.md to define security policy (issue #891)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this repository, please report it responsibly.
+
+- Do NOT open a public issue for security vulnerabilities.
+- Instead, report the issue privately to the OWASP team.
+
+You can contact OWASP via:
+- https://owasp.org/contact/
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+## Supported Versions
+
+This project is actively maintained. Please ensure you are using the latest version before reporting issues.
+
+## Responsible Disclosure
+
+We follow responsible disclosure practices. We appreciate your efforts in improving the security of this project.


### PR DESCRIPTION
This PR adds a SECURITY.md file to the repository.

It provides clear instructions for reporting security vulnerabilities and aligns the project with GitHub security best practices.

Fixes #891