### PR TITLE
Fix incorrect CWE names in A07 and A09 mapped CWE lists (#936)

### DIFF
--- a/2025/docs/en/A07_2025-Authentication_Failures.md
+++ b/2025/docs/en/A07_2025-Authentication_Failures.md
@@ -148,9 +148,9 @@ When an attacker is able to trick a system into recognizing an invalid or incorr
 
 * [CWE-297 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/297.html)
 
-* [CWE-298 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/298.html)
+* [CWE-298 Improper Validation of Certificate Expiration](https://cwe.mitre.org/data/definitions/298.html)
 
-* [CWE-299 Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/299.html)
+* [CWE-299 Improper Check for Certificate Revocation](https://cwe.mitre.org/data/definitions/299.html)
 
 * [CWE-300 Channel Accessible by Non-Endpoint](https://cwe.mitre.org/data/definitions/300.html)
 

--- a/2025/docs/en/A09_2025-Security_Logging_and_Alerting_Failures.md
+++ b/2025/docs/en/A09_2025-Security_Logging_and_Alerting_Failures.md
@@ -127,7 +127,7 @@ There are commercial and open-source application protection products such as the
 
 * [CWE-117 Improper Output Neutralization for Logs](https://cwe.mitre.org/data/definitions/117.html)
 
-* [CWE-221 Information Loss of Omission](https://cwe.mitre.org/data/definitions/221.html)
+* [CWE-221 Information Loss or Omission](https://cwe.mitre.org/data/definitions/221.html)
 
 * [CWE-223 Omission of Security-relevant Information](https://cwe.mitre.org/data/definitions/223.html)
 


### PR DESCRIPTION
This PR corrects the names of CWE-298, CWE-299, and CWE-221 in the "List of Mapped CWEs" section for A07 and A09.

The names have been updated to match the official CWE definitions from MITRE.

- CWE-298: Updated to "Improper Validation of Certificate Expiration"
- CWE-299: Updated to "Improper Check for Certificate Revocation"
- CWE-221: Corrected typo ("of" → "or")

Fixes #936