### PR TITLE
Fix incorrect CWE-201 name in A01 mapped CWE list (#930)

### DIFF
--- a/2025/docs/en/A01_2025-Broken_Access_Control.md
+++ b/2025/docs/en/A01_2025-Broken_Access_Control.md
@@ -157,7 +157,7 @@ from the command line.
 
 * [CWE-200 Exposure of Sensitive Information to an Unauthorized Actor](https://cwe.mitre.org/data/definitions/200.html)
 
-* [CWE-201 Exposure of Sensitive Information Through Sent Data](https://cwe.mitre.org/data/definitions/201.html)
+* [CWE-201 Insertion of Sensitive Information Into Sent Data](https://cwe.mitre.org/data/definitions/201.html)
 
 * [CWE-219 Storage of File with Sensitive Data Under Web Root](https://cwe.mitre.org/data/definitions/219.html)
 


### PR DESCRIPTION
### Summary
Corrected the name of CWE-201 in the A01:2025 mapped CWE list.

### Changes
- Updated "Exposure of Sensitive Information Through Sent Data"
  → to "Insertion of Sensitive Information Into Sent Data"
- Aligned with official CWE definition

### Reference
- https://cwe.mitre.org/data/definitions/201.html

Fixes #930