### PR TITLE
Improve table in 2025 `0x02_2025-What_are_Application_Security_Risks.md`

### DIFF
--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -3,25 +3,9 @@ Attackers can potentially use many different paths through your application to d
 
 ![Calculation diagram](../assets/2025-algorithm-diagram.png)
 
-<table>
-  <tr>
-   <th>Threat Agents</th>
-   <th>Attack Vectors</th>
-   <th>Exploitability</th>
-   <th>Likelihood of Missing Security Controls</th>
-   <th>Technical Impacts</th>
-   <th>Business Impacts</th>
-  </tr>
-  <tr>
-   <td>By environment, dynamic by situation picture</td>
-   <td>By application exposure (by environment)</td>
-   <td>Average weighted exploitability</td>
-   <td>Missing controls by average incidence rate weighted by coverage</td>
-   <td>Average weighted impact</td>
-   <td>By business</td>
-  </tr>
-</table>
-
+| Threat Agents | Attack Vectors | Exploitability | Likelihood of Missing Security Controls | Technical Impacts | Business Impacts |
+| --- | --- | --- | --- | --- | --- |
+| Varies by environment and context | Based on application exposure | Average weighted exploitability | Weighted by incidence rate and control coverage | Average weighted impact | Based on business impact |
 
 In our Risk Rating we have taken into account the universal parameters of exploitability, average likelihood of missing security controls for a weakness and its technical impacts. 
 

--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -5,50 +5,25 @@ Attackers can potentially use many different paths through your application to d
 
 <table>
   <tr>
-   <td>
-    <strong>Threat Agents</strong>
-   </td>
-   <td>
-    <strong>Attack \
-Vectors</strong>
-   </td>
-   <td>
-    <strong>Exploitability</strong>
-   </td>
-   <td>
-    <strong>Likelihood of Missing Security</strong>
-<p style="text-align: center">
-
-    <strong>Controls</strong>
-   </td>
-   <td>
-    <strong>Technical</strong>
-<p style="text-align: center">
-
-    <strong>Impacts</strong>
-   </td>
-   <td>
-    <strong>Business</strong>
-<p style="text-align: center">
-
-    <strong>Impacts</strong>
-   </td>
+   <th>Threat Agents</th>
+   <th>Attack Vectors</th>
+   <th>Exploitability</th>
+   <th>Likelihood of Missing Security Controls</th>
+   <th>Technical Impacts</th>
+   <th>Business Impacts</th>
   </tr>
   <tr>
    <td>
-    <strong>By environment, \
-dynamic by situation picture</strong>
+    <strong>By environment, dynamic by situation picture</strong>
    </td>
    <td>
-    <strong>By Application  exposure (by environment)</strong>
+    <strong>By Application exposure (by environment)</strong>
    </td>
    <td>
-    <strong>Avg Weighted Exploit</strong>
+    <strong>Avg Weighted Exploitability</strong>
    </td>
    <td>
-    <strong>Missing Controls \
-by average Incidence rate \
-Weighed by coverage</strong>
+    <strong>Missing Controls by average Incidence rate Weighted by coverage</strong>
    </td>
    <td>
     <strong>Avg Weighted Impact</strong>

--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -17,19 +17,19 @@ Attackers can potentially use many different paths through your application to d
     <strong>By environment, dynamic by situation picture</strong>
    </td>
    <td>
-    <strong>By Application exposure (by environment)</strong>
+    <strong>By application exposure (by environment)</strong>
    </td>
    <td>
-    <strong>Avg Weighted Exploitability</strong>
+    <strong>Avg weighted exploitability</strong>
    </td>
    <td>
-    <strong>Missing Controls by average Incidence rate Weighted by coverage</strong>
+    <strong>Missing controls by average incidence rate weighted by coverage</strong>
    </td>
    <td>
-    <strong>Avg Weighted Impact</strong>
+    <strong>Avg weighted impact</strong>
    </td>
    <td>
-    <strong>By Business</strong>
+    <strong>By business</strong>
    </td>
   </tr>
 </table>

--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -20,13 +20,13 @@ Attackers can potentially use many different paths through your application to d
     <strong>By application exposure (by environment)</strong>
    </td>
    <td>
-    <strong>Avg weighted exploitability</strong>
+    <strong>Average weighted exploitability</strong>
    </td>
    <td>
     <strong>Missing controls by average incidence rate weighted by coverage</strong>
    </td>
    <td>
-    <strong>Avg weighted impact</strong>
+    <strong>Average weighted impact</strong>
    </td>
    <td>
     <strong>By business</strong>

--- a/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
+++ b/2025/docs/en/0x02_2025-What_are_Application_Security_Risks.md
@@ -13,24 +13,12 @@ Attackers can potentially use many different paths through your application to d
    <th>Business Impacts</th>
   </tr>
   <tr>
-   <td>
-    <strong>By environment, dynamic by situation picture</strong>
-   </td>
-   <td>
-    <strong>By application exposure (by environment)</strong>
-   </td>
-   <td>
-    <strong>Average weighted exploitability</strong>
-   </td>
-   <td>
-    <strong>Missing controls by average incidence rate weighted by coverage</strong>
-   </td>
-   <td>
-    <strong>Average weighted impact</strong>
-   </td>
-   <td>
-    <strong>By business</strong>
-   </td>
+   <td>By environment, dynamic by situation picture</td>
+   <td>By application exposure (by environment)</td>
+   <td>Average weighted exploitability</td>
+   <td>Missing controls by average incidence rate weighted by coverage</td>
+   <td>Average weighted impact</td>
+   <td>By business</td>
   </tr>
 </table>
 

--- a/2025/docs/en/0x03_2025-Establishing_a_Modern_Application_Security_Program.md
+++ b/2025/docs/en/0x03_2025-Establishing_a_Modern_Application_Security_Program.md
@@ -42,7 +42,7 @@ If you are starting a program from scratch, or you find OWASP SAMM or DSOMM ‘t
 
 * Review your current system development life cycle and all software security activities, tooling, policies, and processes, then document them.
 
-* For new software, add one or more security activities to each phase of the system development life cycle (SDLC). Below we offer many suggestions of what you can do below. Ensure you perform these new activities on every new project or software initiative, this way you will know each new piece of software will be delivered at an acceptable security posture for your organizations.
+* For new software, add one or more security activities to each phase of the system development life cycle (SDLC). Below we offer many suggestions of what you can do. Ensure you perform these new activities on every new project or software initiative, this way you will know each new piece of software will be delivered at an acceptable security posture for your organizations.
 
 * Select your activities to ensure your final product meets an acceptable level of risk for your organization.
 


### PR DESCRIPTION
- replace HTML table with markdown one
- fix typo and improve grammar (disclaimer: used LLM because for some sentences I really don't understand what it means)

[Current table](https://owasp.org/Top10/2025/0x02_2025-What_are_Application_Security_Risks/):
<img width="785" height="264" alt="image" src="https://github.com/user-attachments/assets/e4174b9a-129d-4318-82fe-9359548941bc" />

This PR:
<img width="803" height="274" alt="image" src="https://github.com/user-attachments/assets/886be88b-37aa-4ca2-8d34-f44c988fbb6a" />


