### PR TITLE
Fix typo in 2025 Next Steps

### DIFF
--- a/2025/docs/en/X01_2025-Next_Steps.md
+++ b/2025/docs/en/X01_2025-Next_Steps.md
@@ -153,7 +153,7 @@ In order to prevent this type of vulnerability you must design for failure and r
 
 ### Background. 
 
-Languagess like Java, C#, JavaScript/TypeScript (node.js), Go, and "safe" Rust are memory safe. Memory management problems tend to happen in non-memory safe languages such as C and C++. This category scored the lowest on the community survey and low in the data despite having the third most related CVEs. We believe this is due to the predominance of web applications over more traditional desktop applications. Memory management vulnerabilities frequently have the highest CVSS scores. 
+Languages like Java, C#, JavaScript/TypeScript (node.js), Go, and "safe" Rust are memory safe. Memory management problems tend to happen in non-memory safe languages such as C and C++. This category scored the lowest on the community survey and low in the data despite having the third most related CVEs. We believe this is due to the predominance of web applications over more traditional desktop applications. Memory management vulnerabilities frequently have the highest CVSS scores.
 
 
 ### Score table.


### PR DESCRIPTION
## Summary

- Correct `Languagess` to `Languages` in the X02:2025 background section.
- Remove trailing whitespace from the corrected line.

## Why

The typo appears in the English 2025 Next Steps documentation and in the rendered website.

## Impact

Readers see the correct spelling. There is no functional or security behavior change.

## Validation

- `git diff --check`
- `mkdocs build --site-dir ../build/2025` from the `2025` directory
- Confirmed the corrected sentence in the rendered HTML

Fixes #959
