### PR TITLE
Add generated PDF editions for 2021 and 2025

### DIFF
--- a/2021/docs/en/index.md
+++ b/2021/docs/en/index.md
@@ -6,6 +6,8 @@ Welcome to the OWASP Top 10:2021 documentation.
 
 The OWASP Top 10 is a standard awareness document for developers and web application security. It represents a broad consensus about the most critical security risks to web applications.
 
+<a href="downloads/OWASP-Top-10-2021-en.pdf">Download the English PDF edition</a>
+
 ## Getting Started
 
 Start with the [Introduction](A00_2021_Introduction.md) to learn about the OWASP Top 10:2021.

--- a/2021/mkdocs-pdf.yml
+++ b/2021/mkdocs-pdf.yml
@@ -1,0 +1,21 @@
+INHERIT: mkdocs.yml
+
+# Build the English source tree without the i18n plugin. mkdocs-to-pdf and
+# mkdocs-static-i18n do not currently support generating one PDF per locale.
+docs_dir: !ENV [PDF_DOCS_DIR, docs/en]
+
+plugins:
+  - search
+  - to-pdf:
+      author: OWASP Top 10 Team
+      cover_logo: assets/OWASP_Logo_Transp.png
+      cover_subtitle: English edition
+      custom_template_path: pdf-template
+      toc_level: 2
+      ordered_chapter_level: 2
+      output_path: downloads/OWASP-Top-10-2021-en.pdf
+  - macros:
+      module_name: '../osib/osib_macro'
+      include_dir: '../osib/include'
+      verbose: false
+      on_error_fail: true

--- a/2021/pdf-template/styles.scss
+++ b/2021/pdf-template/styles.scss
@@ -1,0 +1,15 @@
+.md-typeset table:not([class]) {
+  table-layout: fixed;
+  width: 100%;
+
+  th,
+  td {
+    min-width: 0;
+    overflow-wrap: normal;
+    padding: 0.35em 0.1rem;
+  }
+
+  th {
+    font-size: 6pt;
+  }
+}

--- a/2025/docs/en/index.md
+++ b/2025/docs/en/index.md
@@ -4,6 +4,8 @@ Welcome to the OWASP Top 10:2025 Release.
 
 The OWASP Top 10 is a standard awareness document for developers and web application security. It represents a broad consensus about the most critical security risks to web applications.
 
+<a href="downloads/OWASP-Top-10-2025-en.pdf">Download the English PDF edition</a>
+
 ## About This Release
 
 This is the **2025** version of the OWASP Top 10. This version includes updates based on the latest data and security trends.

--- a/2025/mkdocs-pdf.yml
+++ b/2025/mkdocs-pdf.yml
@@ -1,0 +1,20 @@
+INHERIT: mkdocs.yml
+
+# Build only the English navigation without the i18n plugin. The base 2025
+# navigation already points to files under docs/en/.
+docs_dir: !ENV [PDF_DOCS_DIR, docs]
+
+plugins:
+  - search
+  - to-pdf:
+      author: OWASP Top 10 Team
+      cover_logo: assets/OWASP_Logo_Transp.png
+      cover_subtitle: English edition
+      toc_level: 2
+      ordered_chapter_level: 2
+      output_path: downloads/OWASP-Top-10-2025-en.pdf
+  - macros:
+      module_name: '../osib/osib_macro'
+      include_dir: '../osib/include'
+      verbose: false
+      on_error_fail: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,12 @@ make all          # Install dependencies and build both sites
 make build-all    # Just build both sites
 ```
 
+`make all` also generates downloadable English PDF editions and requires
+Python 3.10 or newer. To add PDF support to an existing virtual environment,
+run `make install-pdf-requirements`, then `make build-pdfs`. PDF rendering
+also needs WeasyPrint's system libraries (`brew install weasyprint` on macOS,
+or the WeasyPrint/Pango packages supplied by your Linux distribution).
+
 **Serve both versions together:**
 ```bash
 make serve        # Builds and serves both versions on port 8000
@@ -58,14 +64,16 @@ make build-2021  # Builds to build/2021/
 make build-2025  # Builds to build/2025/
 ```
 
-**Build both versions together:**
+**Build both versions together, including PDFs:**
 ```bash
-make build-all
+make build-pdfs
 ```
 
 This creates a combined build with:
 - `build/2021/` - Complete 2021 site
 - `build/2025/` - Complete 2025 site
+- `build/2021/downloads/OWASP-Top-10-2021-en.pdf` - 2021 English PDF
+- `build/2025/downloads/OWASP-Top-10-2025-en.pdf` - 2025 English PDF
 - `build/index.html` - Root redirect to 2021
 - `build/en/`, `build/ar/`, etc. - HTML redirects for backward compatibility
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ install-python-requirements:  # Install Python 3 required libraries
 	fi 
 	($(DEBUG) $(activate) && $(DEBUG) python3 -m pip install -r requirements.txt && $(DEBUG) python3 -m pip install --upgrade pip)
 
+install-pdf-requirements: install-python-requirements  # Install optional PDF build libraries (Python 3.10+)
+	($(DEBUG) $(activate) && $(DEBUG) python3 -c 'import sys; sys.exit("PDF builds require Python 3.10 or newer") if sys.version_info < (3, 10) else None' && $(DEBUG) python3 -m pip install -r requirements-pdf.txt)
+
 build-2021:  # Build 2021 site only
 	($(activate) && cd 2021 && mkdocs build --site-dir ../build/2021)
 
@@ -33,6 +36,9 @@ build-2025:  # Build 2025 site only
 
 build-all:  # Build both sites with redirects
 	./scripts/build-all.sh
+
+build-pdfs: build-all  # Build both sites and their downloadable English PDFs
+	./scripts/build-pdfs.sh
 
 build: build-all  # Alias for build-all
 
@@ -62,8 +68,9 @@ serve: build-all  # Serve both 2021 and 2025 sites from build directory
 
 generate: build-2021  # Maintain backward compatibility (keep existing)
 
-all: install-python-requirements build-all  # Install requirements and build both sites
+all: install-pdf-requirements build-pdfs  # Install requirements and build both sites with PDFs
 
-publish: build-all  # Deploy both sites to GitHub Pages
+publish: build-pdfs  # Deploy both sites and downloadable PDFs to GitHub Pages
 	($(activate) && cd build && git init -b main && git add -A && git commit -m "Deploy both 2021 and 2025 sites" && git push -f git@github.com:OWASP/Top10.git main:gh-pages)
 
+.PHONY: install-pdf-requirements build-pdfs

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 
 We have released the OWASP Top 10:2025 (Final):
 - [OWASP Top10:2025](https://owasp.org/Top10/2025/)
+- [OWASP Top10:2025 (English PDF)](https://owasp.org/Top10/2025/downloads/OWASP-Top-10-2025-en.pdf)
 
 Please log any [feedback, comments, or log issues](https://github.com/OWASP/Top10/issues) here.
 
 ## OWASP Top 10 2021 - SUPERSEDED
 
 - [OWASP Top10:2021](https://owasp.org/Top10/2021/)
+- [OWASP Top10:2021 (English PDF)](https://owasp.org/Top10/2021/downloads/OWASP-Top-10-2021-en.pdf)
 
 ## OWASP Top 10 2017 - HISTORIC
 

--- a/requirements-pdf.txt
+++ b/requirements-pdf.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+mkdocs-to-pdf==0.11.2

--- a/scripts/build-pdfs.sh
+++ b/scripts/build-pdfs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pdf_work_dir="$(mktemp -d "${TMPDIR:-/tmp}/owasp-top10-pdf.XXXXXX")"
+
+# Python launched from a macOS shell may not inherit Homebrew's library path.
+# WeasyPrint needs these libraries to load Pango when used as a Python module.
+if [[ "$(uname -s)" == "Darwin" && -d /opt/homebrew/lib ]]; then
+    export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}"
+fi
+
+cleanup() {
+    case "${pdf_work_dir}" in
+        */owasp-top10-pdf.*) rm -rf -- "${pdf_work_dir}" ;;
+        *) echo "Refusing to remove unexpected PDF work directory: ${pdf_work_dir}" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+build_pdf() {
+    version="$1"
+    filename="OWASP-Top-10-${version}-en.pdf"
+    version_work_dir="${pdf_work_dir}/${version}"
+    staged_docs_dir="${pdf_work_dir}/${version}-docs"
+    destination_dir="${repo_root}/build/${version}/downloads"
+
+    echo "Building ${version} English PDF..."
+    mkdir -p "${staged_docs_dir}"
+    if [[ "${version}" == "2021" ]]; then
+        cp -R "${repo_root}/${version}/docs/en/." "${staged_docs_dir}/"
+        rm -f -- "${staged_docs_dir}/0x00_2021-introduction.md"
+    else
+        mkdir -p "${staged_docs_dir}/en"
+        cp -R "${repo_root}/${version}/docs/en/." "${staged_docs_dir}/en/"
+    fi
+    cp -R "${repo_root}/${version}/docs/assets" "${staged_docs_dir}/assets"
+
+    (
+        cd "${repo_root}/${version}"
+        PDF_DOCS_DIR="${staged_docs_dir}" \
+            mkdocs build --config-file mkdocs-pdf.yml --site-dir "${version_work_dir}"
+    )
+
+    mkdir -p "${destination_dir}"
+    install -m 0644 \
+        "${version_work_dir}/downloads/${filename}" \
+        "${destination_dir}/${filename}"
+}
+
+build_pdf 2021
+build_pdf 2025
+
+echo "PDF build complete."
+echo "  - build/2021/downloads/OWASP-Top-10-2021-en.pdf"
+echo "  - build/2025/downloads/OWASP-Top-10-2025-en.pdf"


### PR DESCRIPTION
## Summary

- generate downloadable English PDF editions for the 2021 and 2025 MkDocs sites
- publish the PDFs with the existing combined site and link them from both homepages and the repository README
- document the optional PDF dependencies and build targets

## Root cause

The project build generated only HTML. It had no reproducible PDF configuration, dependency set, build target, or deployment integration, so the 2021 and 2025 editions could not be downloaded as PDFs.

## Implementation

The new PDF build stages only English content plus shared assets, avoiding overlap with the site's multilingual HTML build. It uses pinned `mkdocs-to-pdf` tooling, adds an explicit Python 3.10 preflight, and preserves the normal HTML-only `build-all` and live-serve workflows. A PDF-only 2021 table style keeps the legacy nine-column factor tables within the A4 page boundary.

The generated PDFs are placed at:

- `build/2021/downloads/OWASP-Top-10-2021-en.pdf`
- `build/2025/downloads/OWASP-Top-10-2025-en.pdf`

## Validation

- `PATH=<clean Python 3.12 venv>/bin:$PATH make build-pdfs` — passed from a clean `build/`; HTML builds completed in 10.50s (2021) and 6.65s (2025), then PDF conversion completed for 17 and 16 source articles respectively
- PDF structure/content checks with `pypdf` — passed: 2021 is 59 A4 pages and 2025 is 69 A4 pages; both include A01-A10, have 16 outline entries, no encryption, no low-text/blank pages, and no invalid link schemes
- rendered every PDF page with Poppler — 128/128 pages rendered and visually inspected; the final clean-build renders were pixel-identical to the inspected set
- local rendered-site browser smoke test — both homepage links were visible and navigated to their PDF endpoints with HTTP 200
- `shellcheck scripts/build-pdfs.sh`, `bash -n scripts/build-pdfs.sh`, and `git diff --check` — passed
- Python boundary check — Python 3.9 exits with the documented requirement; Python 3.12 passes

The clean build retained 14 existing MkDocs i18n warnings and two existing LibreSSL notices. WeasyPrint also emitted 12 Fontconfig error/warning pairs and two font-metadata notices on this macOS environment; PDF generation completed successfully and the rendered output was verified page by page.

Fixes #934
